### PR TITLE
refactor(frontend): chunk 1 — introduce ParserContext state carrier

### DIFF
--- a/pylisa/src/main/java/it/unive/pylisa/frontend/ParserContext.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/ParserContext.java
@@ -1,0 +1,179 @@
+package it.unive.pylisa.frontend;
+
+import it.unive.lisa.program.CompilationUnit;
+import it.unive.lisa.program.Program;
+import it.unive.lisa.program.Unit;
+import it.unive.lisa.program.cfg.controlFlow.ControlFlowStructure;
+import it.unive.pylisa.cfg.PyCFG;
+import it.unive.pylisa.program.ModuleUnit;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Mutable parsing state shared by the PyLiSA front-end visitors.
+ * <p>
+ * Introduced in Chunk 1 of the front-end refactor. Takes the place of the
+ * {@code protected} fields that used to live on {@link PyFrontendBase} and leak
+ * across the four-level visitor inheritance chain. All access now goes through
+ * this object, so a future chunk can flatten the inheritance into sibling
+ * visitors without chasing state across class boundaries.
+ * </p>
+ */
+public final class ParserContext {
+
+	private static final Logger LOG = LogManager.getLogger(ParserContext.class);
+
+	private Program program;
+	private PythonModuleImportManager importManager;
+	private ModuleUnit currentModule;
+	private CompilationUnit objectUnit;
+	private Unit currentUnit;
+	private PyCFG currentCFG;
+	private Collection<ControlFlowStructure> cfs;
+	private Map<String, String> imports = new HashMap<>();
+	private boolean shouldPrependUnitAccess = true;
+	private final Deque<Set<String>> localScopes = new ArrayDeque<>();
+
+	// === field accessors (package-private — every consumer lives in
+	// it.unive.pylisa.frontend) ===
+
+	Program program() {
+		return program;
+	}
+
+	void program(
+			Program p) {
+		this.program = p;
+	}
+
+	PythonModuleImportManager importManager() {
+		return importManager;
+	}
+
+	void importManager(
+			PythonModuleImportManager m) {
+		this.importManager = m;
+	}
+
+	ModuleUnit currentModule() {
+		return currentModule;
+	}
+
+	void currentModule(
+			ModuleUnit m) {
+		this.currentModule = m;
+	}
+
+	CompilationUnit objectUnit() {
+		return objectUnit;
+	}
+
+	void objectUnit(
+			CompilationUnit u) {
+		this.objectUnit = u;
+	}
+
+	Unit currentUnit() {
+		return currentUnit;
+	}
+
+	void currentUnit(
+			Unit u) {
+		this.currentUnit = u;
+	}
+
+	PyCFG currentCFG() {
+		return currentCFG;
+	}
+
+	void currentCFG(
+			PyCFG c) {
+		this.currentCFG = c;
+	}
+
+	Collection<ControlFlowStructure> cfs() {
+		return cfs;
+	}
+
+	void cfs(
+			Collection<ControlFlowStructure> c) {
+		this.cfs = c;
+	}
+
+	Map<String, String> imports() {
+		return imports;
+	}
+
+	void imports(
+			Map<String, String> m) {
+		this.imports = m;
+	}
+
+	boolean shouldPrependUnitAccess() {
+		return shouldPrependUnitAccess;
+	}
+
+	void shouldPrependUnitAccess(
+			boolean v) {
+		this.shouldPrependUnitAccess = v;
+	}
+
+	// === scope-stack operations (public API for visitors) ===
+
+	public void enterLocalScope() {
+		localScopes.push(new HashSet<>());
+		LOG.trace("enterLocalScope depth={}", localScopes.size());
+	}
+
+	public void exitLocalScope() {
+		if (!localScopes.isEmpty()) {
+			localScopes.pop();
+			LOG.trace("exitLocalScope depth={}", localScopes.size());
+		}
+	}
+
+	public boolean isInsideLocalScope() {
+		return !localScopes.isEmpty();
+	}
+
+	public void declareNameInCurrentScope(
+			String name) {
+		if (!localScopes.isEmpty() && name != null && !name.isEmpty())
+			localScopes.peek().add(name);
+	}
+
+	public boolean isNameInVisibleLocalScope(
+			String name) {
+		if (name == null || name.isEmpty())
+			return false;
+		for (Set<String> scope : localScopes)
+			if (scope.contains(name))
+				return true;
+		return false;
+	}
+
+	/**
+	 * Returns true if {@code name} is declared in the topmost (innermost) scope
+	 * frame only. Used inside function/method bodies to implement the L step of
+	 * Python LEGB resolution: only the method's own local scope is considered;
+	 * enclosing class-body scope frames are intentionally excluded.
+	 *
+	 * @param name the name to look up
+	 *
+	 * @return {@code true} if {@code name} is in the top scope frame
+	 */
+	public boolean isNameInTopLocalScope(
+			String name) {
+		if (name == null || name.isEmpty())
+			return false;
+		Set<String> top = localScopes.peek();
+		return top != null && top.contains(name);
+	}
+}

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/PyDefinitionVisitorBase.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/PyDefinitionVisitorBase.java
@@ -120,7 +120,7 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 		} else {
 			return unsupported(ctx, "Expecting {'def', 'class', 'async'} after decorators");
 		}
-		PyAssign pyAssign = new PyAssign(currentCFG, getLocation(ctx), innerAssign, result);
+		PyAssign pyAssign = new PyAssign(this.ctx.currentCFG(), getLocation(ctx), innerAssign, result);
 		block.addNode(pyAssign);
 		return Triple.of(pyAssign, block, pyAssign);
 	}
@@ -146,7 +146,8 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 				for (ArgumentContext arg : ctx.arglist().argument())
 					params.add(visitArgument(arg));
 			params = convertAssignmentsToByNameParameters(params);
-			return new FunctionApply(currentCFG, getLocation(ctx), result, params.toArray(Expression[]::new));
+			return new FunctionApply(this.ctx.currentCFG(), getLocation(ctx), result,
+					params.toArray(Expression[]::new));
 		}
 		List<Expression> params = new ArrayList<>();
 		String varName = ctx.dotted_name().children.get(0).getText();
@@ -155,7 +156,7 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 			for (ArgumentContext arg : ctx.arglist().argument())
 				params.add(visitArgument(arg));
 		params = convertAssignmentsToByNameParameters(params);
-		return new FunctionApply(currentCFG, getLocation(ctx), result, params.toArray(Expression[]::new));
+		return new FunctionApply(this.ctx.currentCFG(), getLocation(ctx), result, params.toArray(Expression[]::new));
 	}
 
 	public Expression visitDecorators(
@@ -181,7 +182,7 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 						? decorator
 						: decorator.getSubExpressions()[0];
 				result = new FunctionApply(
-						currentCFG,
+						this.ctx.currentCFG(),
 						getLocation(ctx),
 						callTarget,
 						List.of(result).toArray(Expression[]::new));
@@ -202,19 +203,21 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 	public Triple<Statement, NodeList<CFG, Statement, Edge>, Statement> visitFuncdef(
 			FuncdefContext ctx) {
 		NodeList<CFG, Statement, Edge> block = new NodeList<>(SEQUENTIAL_SINGLETON);
-		PyCFG oldCFG = currentCFG;
-		Collection<ControlFlowStructure> oldCfs = cfs;
+		PyCFG oldCFG = this.ctx.currentCFG();
+		Collection<ControlFlowStructure> oldCfs = this.ctx.cfs();
 
-		FunctionUnit unit = new FunctionUnit(getLocation(ctx), program, currentUnit + "." + ctx.NAME().getText(),
+		FunctionUnit unit = new FunctionUnit(getLocation(ctx), this.ctx.program(),
+				this.ctx.currentUnit() + "." + ctx.NAME().getText(),
 				false);
 		PyFunctionType.register(unit.getName(), unit);
-		PyCFG newCFG = currentCFG = new PyCFG(buildCFGDescriptor(ctx, unit));
+		PyCFG newCFG = new PyCFG(buildCFGDescriptor(ctx, unit));
+		this.ctx.currentCFG(newCFG);
 		unit.setFunction(newCFG);
 		unit.addCodeMember(newCFG);
-		program.addUnit(unit);
-		cfs = new HashSet<>();
-		Unit prevUnit = currentUnit;
-		currentUnit = unit;
+		this.ctx.program().addUnit(unit);
+		this.ctx.cfs(new HashSet<>());
+		Unit prevUnit = this.ctx.currentUnit();
+		this.ctx.currentUnit(unit);
 		enterLocalScope();
 		try {
 			for (PyParameter parameter : visitParameters(ctx.parameters()))
@@ -224,37 +227,38 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 				throw e;
 			log.warn("[PyLiSA] Skipping unsupported parameter in " + unit.getName()
 					+ ": " + e.getMessage());
-			// currentCFG is still newCFG; the finally below will restore it
+			// this.ctx.currentCFG() is still newCFG; the finally below will
+			// restore it
 		}
 		try {
 			Triple<Statement, NodeList<CFG, Statement, Edge>, Statement> r = visitSuite(ctx.suite());
-			currentUnit = prevUnit;
-			currentCFG.getNodeList().mergeWith(r.getMiddle());
-			currentCFG.getEntrypoints().add(r.getLeft());
+			this.ctx.currentUnit(prevUnit);
+			this.ctx.currentCFG().getNodeList().mergeWith(r.getMiddle());
+			this.ctx.currentCFG().getEntrypoints().add(r.getLeft());
 			addRetNodesToCurrentCFG();
-			cfs.forEach(currentCFG.getDescriptor()::addControlFlowStructure);
-			currentCFG.simplify();
+			this.ctx.cfs().forEach(this.ctx.currentCFG().getDescriptor()::addControlFlowStructure);
+			this.ctx.currentCFG().simplify();
 		} catch (Exception e) {
 			// Finalize the function CFG even if parsing partially failed
 			addRetNodesToCurrentCFG();
-			currentUnit = prevUnit;
+			this.ctx.currentUnit(prevUnit);
 			throw e;
 		} finally {
 			exitLocalScope();
-			currentCFG = oldCFG;
-			cfs = oldCfs;
+			this.ctx.currentCFG(oldCFG);
+			this.ctx.cfs(oldCfs);
 		}
 		Expression target;
-		if (currentUnit instanceof ModuleUnit pmu) {
+		if (this.ctx.currentUnit() instanceof ModuleUnit pmu) {
 			target = makeScopedAttributeRef(pmu, ctx.NAME().getText(), getLocation(ctx));
-		} else if (currentUnit instanceof ClassUnit cu) {
+		} else if (this.ctx.currentUnit() instanceof ClassUnit cu) {
 			target = makeScopedAttributeRef(cu, ctx.NAME().getText(), getLocation(ctx));
 		} else {
 			declareNameInCurrentScope(ctx.NAME().getText());
-			target = new VariableRef(this.currentCFG, getLocation(ctx), ctx.NAME().getText());
+			target = new VariableRef(this.ctx.currentCFG(), getLocation(ctx), ctx.NAME().getText());
 		}
-		PyAssign funcAssign = new PyAssign(this.currentCFG, getLocation(ctx), target,
-				new ImportFunction(currentCFG, SyntheticLocation.INSTANCE, unit.getName(), unit));
+		PyAssign funcAssign = new PyAssign(this.ctx.currentCFG(), getLocation(ctx), target,
+				new ImportFunction(this.ctx.currentCFG(), SyntheticLocation.INSTANCE, unit.getName(), unit));
 		block.addNode(funcAssign);
 		return Triple.of(funcAssign, block, funcAssign);
 	}
@@ -273,9 +277,10 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 		List<PyParameter> pars = new LinkedList<>();
 		for (TypedargContext typedArg : ctx.typedarg())
 			if (pars.isEmpty())
-				if (currentUnit instanceof ClassUnit) {
+				if (this.ctx.currentUnit() instanceof ClassUnit) {
 					pars.add(new PyParameter(getLocation(typedArg), typedArg.tfpdef().NAME().getText(),
-							new ReferenceType(PyClassType.register(currentUnit.getName(), (ClassUnit) currentUnit))));
+							new ReferenceType(PyClassType.register(this.ctx.currentUnit().getName(),
+									(ClassUnit) this.ctx.currentUnit()))));
 				} else
 					pars.add(visitTypedarg(typedArg));
 			else
@@ -352,7 +357,7 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 
 		// attach classInit to the class unit
 		NodeList<CFG, Statement, Edge> block = new NodeList<>(SEQUENTIAL_SINGLETON);
-		Unit previous = this.currentUnit;
+		Unit previous = this.ctx.currentUnit();
 		String name = ctx.NAME().getSymbol().getText();
 		String baseFqName = previous.getName() + "." + name;
 		// Allocation-site abstraction: each `class` statement mints a fresh
@@ -361,14 +366,14 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 		// Secret: …`) share `baseFqName` but get distinct identity names like
 		// `dispatch.config.Secret@24:4` and `…@38:4`, so the PyClassType
 		// registry never silently merges them. Name-level resolution
-		// (imports, attribute access, inheritance) goes through
+		// (this.ctx.imports(), attribute access, inheritance) goes through
 		// {@link PyClassType#lookupAllByBaseName} which returns the set of
 		// def-sites for a given qualified name.
 		SourceCodeLocation classLoc = getLocation(ctx);
 		String fqName = baseFqName + "@" + classLoc.getLine() + ":" + classLoc.getCol();
-		PyClassUnit cu = new PyClassUnit(classLoc, program, fqName, baseFqName, false);
+		PyClassUnit cu = new PyClassUnit(classLoc, this.ctx.program(), fqName, baseFqName, false);
 		PyClassType.register(fqName, cu);
-		this.currentUnit = cu;
+		this.ctx.currentUnit(cu);
 		PyCFG classInit = new PyCFG(buildInitClassCFGDescriptor(SyntheticLocation.INSTANCE));
 		cu.addCodeMember(classInit);
 
@@ -379,9 +384,9 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 		// matching units as ancestors — a sound over-approximation that lets
 		// downstream subclass checks succeed against any possible parent.
 		for (ArgumentContext superclass : superclasses) {
-			String superClassName = imports.getOrDefault(superclass.getText(), superclass.getText());
+			String superClassName = this.ctx.imports().getOrDefault(superclass.getText(), superclass.getText());
 			java.util.Set<it.unive.lisa.program.CompilationUnit> matches = new java.util.LinkedHashSet<>();
-			for (Unit programCu : this.program.getUnits()) {
+			for (Unit programCu : this.ctx.program().getUnits()) {
 				if (!(programCu instanceof it.unive.lisa.program.CompilationUnit programCompUnit))
 					continue;
 				String candidateIdentity = programCu.getName();
@@ -389,8 +394,8 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 						: candidateIdentity;
 				if (candidateIdentity.equals(superClassName) || candidateBase.equals(superClassName))
 					matches.add(programCompUnit);
-				else if (currentModule != null
-						&& candidateBase.equals(currentModule.getName() + "." + superClassName))
+				else if (this.ctx.currentModule() != null
+						&& candidateBase.equals(this.ctx.currentModule().getName() + "." + superClassName))
 					matches.add(programCompUnit);
 				else if (candidateBase.endsWith("." + superClassName))
 					matches.add(programCompUnit);
@@ -399,18 +404,19 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 				cu.addAncestor(match);
 		}
 		if (cu.getImmediateAncestors().isEmpty()) {
-			if (objectUnit != null)
-				cu.addAncestor(objectUnit);
+			if (this.ctx.objectUnit() != null)
+				cu.addAncestor(this.ctx.objectUnit());
 			else
 				log.warn("builtins.object is not available; class '{}' will have no ancestor. "
 						+ "Ensure toLiSAProgram() completes library loading before parsing.", fqName);
 		}
 		log.debug("DEBUG visitClassdef: class '{}' (base '{}') ancestors = {}", fqName, baseFqName,
 				cu.getImmediateAncestors());
-		// Register the class unit in the program BEFORE parsing the body so
+		// Register the class unit in the this.ctx.program() BEFORE parsing the
+		// body so
 		// that
 		// super() detection in method bodies can look up the class by name.
-		program.addUnit(cu);
+		this.ctx.program().addUnit(cu);
 		Triple<Statement, NodeList<CFG, Statement, Edge>, Statement> classInitBody = parseClassBody(ctx.suite());
 		classInit.getNodeList().mergeWith(classInitBody.getMiddle());
 		if (ctx.suite().stmt().isEmpty()) {
@@ -419,21 +425,21 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 			classInit.addEdge(new SequentialEdge(noOp, classInitBody.getLeft()));
 		} else
 			classInit.addNodeIfNotPresent(classInitBody.getLeft(), true);
-		this.currentUnit = previous;
+		this.ctx.currentUnit(previous);
 		Expression target;
-		if (currentUnit instanceof ModuleUnit pmu) {
+		if (this.ctx.currentUnit() instanceof ModuleUnit pmu) {
 			target = makeScopedAttributeRef(pmu, name, getLocation(ctx));
-		} else if (currentUnit instanceof ClassUnit) {
-			target = new AttributeAccess(this.currentCFG, getLocation(ctx),
-					new VariableRef(this.currentCFG, getLocation(ctx), SELF_PARAM_NAME), name);
+		} else if (this.ctx.currentUnit() instanceof ClassUnit) {
+			target = new AttributeAccess(this.ctx.currentCFG(), getLocation(ctx),
+					new VariableRef(this.ctx.currentCFG(), getLocation(ctx), SELF_PARAM_NAME), name);
 		} else {
 			declareNameInCurrentScope(name);
-			target = new VariableRef(this.currentCFG, getLocation(ctx), name);
+			target = new VariableRef(this.ctx.currentCFG(), getLocation(ctx), name);
 		}
-		PyAssign classAssign = new PyAssign(this.currentCFG, getLocation(ctx), target,
-				new ImportClass(currentCFG, SyntheticLocation.INSTANCE, name, cu));
+		PyAssign classAssign = new PyAssign(this.ctx.currentCFG(), getLocation(ctx), target,
+				new ImportClass(this.ctx.currentCFG(), SyntheticLocation.INSTANCE, name, cu));
 		block.addNode(classAssign);
-		// Ret ret = new Ret(currentCFG, SyntheticLocation.INSTANCE);
+		// Ret ret = new Ret(this.ctx.currentCFG(), SyntheticLocation.INSTANCE);
 		// block.addNode(ret);
 		// block.addEdge(new SequentialEdge(classAssign, ret));
 
@@ -504,7 +510,7 @@ public abstract class PyDefinitionVisitorBase extends PyStatementVisitorBase {
 		} finally {
 			exitLocalScope();
 		}
-		Ret ret = new Ret(currentCFG, SyntheticLocation.INSTANCE);
+		Ret ret = new Ret(this.ctx.currentCFG(), SyntheticLocation.INSTANCE);
 		block.addNode(ret);
 		if (last != null)
 			block.addEdge(new SequentialEdge(last, ret));

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/PyExpressionVisitorBase.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/PyExpressionVisitorBase.java
@@ -117,25 +117,28 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 
 			if (text.contains("e") || text.contains("."))
 				// floating point
-				return new Float32Literal(currentCFG, getLocation(ctx), Float.parseFloat(text));
+				return new Float32Literal(this.ctx.currentCFG(), getLocation(ctx), Float.parseFloat(text));
 
 			// integer
 			if (text.startsWith("0x"))
-				return new Int32Literal(currentCFG, getLocation(ctx), Integer.parseInt(text.substring(2), 16));
+				return new Int32Literal(this.ctx.currentCFG(), getLocation(ctx),
+						Integer.parseInt(text.substring(2), 16));
 			if (text.startsWith("0o"))
-				return new Int32Literal(currentCFG, getLocation(ctx), Integer.parseInt(text.substring(2), 8));
+				return new Int32Literal(this.ctx.currentCFG(), getLocation(ctx),
+						Integer.parseInt(text.substring(2), 8));
 			if (text.startsWith("0b"))
-				return new Int32Literal(currentCFG, getLocation(ctx), Integer.parseInt(text.substring(2), 2));
-			return new Int32Literal(currentCFG, getLocation(ctx), Integer.parseInt(text));
+				return new Int32Literal(this.ctx.currentCFG(), getLocation(ctx),
+						Integer.parseInt(text.substring(2), 2));
+			return new Int32Literal(this.ctx.currentCFG(), getLocation(ctx), Integer.parseInt(text));
 		} else if (ctx.FALSE() != null)
 			// create a literal false
-			return new FalseLiteral(currentCFG, getLocation(ctx));
+			return new FalseLiteral(this.ctx.currentCFG(), getLocation(ctx));
 		else if (ctx.TRUE() != null)
 			// create a literal true
-			return new TrueLiteral(currentCFG, getLocation(ctx));
+			return new TrueLiteral(this.ctx.currentCFG(), getLocation(ctx));
 		else if (ctx.NONE() != null)
 			// create a literal false
-			return new PyNoneLiteral(currentCFG, getLocation(ctx));
+			return new PyNoneLiteral(this.ctx.currentCFG(), getLocation(ctx));
 		else if (ctx.STRING().size() > 0)
 			// create a string
 			return strip(getLocation(ctx), ctx.STRING(0).getText());
@@ -146,30 +149,31 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 			return visitDictorsetmaker(ctx.dictorsetmaker());
 		else if (ctx.OPEN_BRACK() != null) {
 			List<Expression> sts = extractExpressionsFromTestlist_comp(ctx.testlist_comp());
-			return new ListCreation(currentCFG, getLocation(ctx), sts.toArray(Expression[]::new));
+			return new ListCreation(this.ctx.currentCFG(), getLocation(ctx), sts.toArray(Expression[]::new));
 		} else if (ctx.OPEN_PAREN() != null) {
 			if (ctx.yield_expr() != null)
 				throw new UnsupportedStatementException("yield expressions not supported");
 			List<Expression> sts = extractExpressionsFromTestlist_comp(ctx.testlist_comp());
 			if (sts.size() <= 1)
-				return sts.isEmpty() ? new TupleCreation(currentCFG, getLocation(ctx)) : sts.get(0);
+				return sts.isEmpty() ? new TupleCreation(this.ctx.currentCFG(), getLocation(ctx)) : sts.get(0);
 			unsound(ctx, "tuple creation treated as first element");
 			return sts.get(0);
 		} else if (ctx.OPEN_BRACE() != null) {
 			// check if it is a dict or a set
 			if (!isADict(ctx.dictorsetmaker())) {
 				List<Expression> values = extractElementsFromSet(ctx.dictorsetmaker());
-				SetCreation s = new SetCreation(currentCFG, getLocation(ctx), values.toArray(Expression[]::new));
+				SetCreation s = new SetCreation(this.ctx.currentCFG(), getLocation(ctx),
+						values.toArray(Expression[]::new));
 				return s;
 			}
 
 			List<Pair<Expression, Expression>> values = extractPairsFromDict(ctx.dictorsetmaker());
 			@SuppressWarnings("unchecked")
-			DictionaryCreation r = new DictionaryCreation(currentCFG, getLocation(ctx),
+			DictionaryCreation r = new DictionaryCreation(this.ctx.currentCFG(), getLocation(ctx),
 					values.toArray(Pair[]::new));
 			return r;
 		} else if (ctx.ELLIPSIS() != null)
-			return new PyEllipsisLiteral(currentCFG, getLocation(ctx));
+			return new PyEllipsisLiteral(this.ctx.currentCFG(), getLocation(ctx));
 		throw new UnsupportedStatementException();
 	}
 
@@ -199,7 +203,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 					// a.b
 					String attr = trailer.NAME().getText();
 					access = new AttributeAccess(
-							currentCFG,
+							this.ctx.currentCFG(),
 							getLocation(trailer),
 							access,
 							attr);
@@ -226,7 +230,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 							&& "super".equals(superRef.getName())
 							&& trailer.arglist() == null
 							&& !receiverWasPrepended
-							&& objectUnit != null) {
+							&& this.ctx.objectUnit() != null) {
 						PyClassUnit enclosingClass = findEnclosingPyClassUnit();
 						if (enclosingClass != null) {
 							String fullName = enclosingClass.getName();
@@ -235,13 +239,16 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 									: fullName;
 							Expression classRef = makeRef(simpleName, getLocation(trailer));
 							log.debug("super() synthesis in '{}': simpleName='{}', classRef='{}' id={}",
-									currentUnit.getName(), simpleName, classRef, System.identityHashCode(classRef));
-							String firstParamName = currentCFG.getDescriptor().getFormals().length > 0
-									? currentCFG.getDescriptor().getFormals()[0].getName()
+									this.ctx.currentUnit().getName(), simpleName, classRef,
+									System.identityHashCode(classRef));
+							String firstParamName = this.ctx.currentCFG().getDescriptor().getFormals().length > 0
+									? this.ctx.currentCFG().getDescriptor().getFormals()[0].getName()
 									: "self";
-							Expression selfRef = new VariableRef(currentCFG, getLocation(trailer), firstParamName);
-							Expression superFunc = makeScopedAttributeRef(objectUnit, "super", getLocation(trailer));
-							access = new FunctionApply(currentCFG, getLocation(trailer), superFunc,
+							Expression selfRef = new VariableRef(this.ctx.currentCFG(), getLocation(trailer),
+									firstParamName);
+							Expression superFunc = makeScopedAttributeRef(this.ctx.objectUnit(), "super",
+									getLocation(trailer));
+							access = new FunctionApply(this.ctx.currentCFG(), getLocation(trailer), superFunc,
 									new Expression[] { classRef, selfRef }, false);
 							log.debug("super() FunctionApply created: id={}", System.identityHashCode(access));
 							accessChain[i] = selfRef; // ← FIX: original self
@@ -259,7 +266,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 
 					args = convertAssignmentsToByNameParameters(args);
 					access = new FunctionApply(
-							currentCFG,
+							this.ctx.currentCFG(),
 							getLocation(trailer),
 							access,
 							args.toArray(Expression[]::new),
@@ -273,9 +280,9 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 						Expression key = visitSubscript_(subs.get(0));
 						Expression receiver = access;
 						Expression getitemAttr = new AttributeAccess(
-								currentCFG, getLocation(trailer), receiver, "__getitem__");
+								this.ctx.currentCFG(), getLocation(trailer), receiver, "__getitem__");
 						access = new FunctionApply(
-								currentCFG, getLocation(trailer), getitemAttr,
+								this.ctx.currentCFG(), getLocation(trailer), getitemAttr,
 								new Expression[] { receiver, key }, true);
 					} else {
 						unsound(trailer, "multiple subscripts not supported");
@@ -299,7 +306,8 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 			Expression booleanGuard = visitOr_test(ctx.or_test(1));
 			Expression falseCase = visitTest(ctx.test());
 
-			PyTernaryOperator ternary = new PyTernaryOperator(currentCFG, getLocation(ctx), booleanGuard, trueCase,
+			PyTernaryOperator ternary = new PyTernaryOperator(this.ctx.currentCFG(), getLocation(ctx), booleanGuard,
+					trueCase,
 					falseCase);
 
 			return ternary;
@@ -332,7 +340,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		return new LambdaExpression(
 				args,
 				body,
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx));
 	}
 
@@ -349,7 +357,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		return new LambdaExpression(
 				args,
 				body,
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx));
 	}
 
@@ -369,7 +377,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 	public Expression visitNot_test(
 			Not_testContext ctx) {
 		if (ctx.NOT() != null)
-			return new Not(currentCFG, getLocation(ctx), visitNot_test(ctx.not_test()));
+			return new Not(this.ctx.currentCFG(), getLocation(ctx), visitNot_test(ctx.not_test()));
 		else
 			return visitComparison(ctx.comparison());
 	}
@@ -391,49 +399,49 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 			Expression left = visitExpr(ctx.expr(0));
 			Expression right = visitExpr(ctx.expr(1));
 			if (operator.EQUALS() != null)
-				result = new PyEquals(currentCFG, getLocation(ctx), left, right);
+				result = new PyEquals(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python greater (>)
 			if (operator.GREATER_THAN() != null) {
-				result = new PyGreaterThan(currentCFG, getLocation(ctx), left, right);
+				result = new PyGreaterThan(this.ctx.currentCFG(), getLocation(ctx), left, right);
 			}
 			// Python greater equal (>=)
 			if (operator.GT_EQ() != null)
-				result = new PyGreaterOrEqual(currentCFG, getLocation(ctx), left, right);
+				result = new PyGreaterOrEqual(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python not in (not in) — must be checked before plain IN
 			if (operator.NOT() != null && operator.IN() != null)
-				result = new Not(currentCFG, getLocation(ctx),
-						new PyIn(currentCFG, getLocation(ctx), left, right));
+				result = new Not(this.ctx.currentCFG(), getLocation(ctx),
+						new PyIn(this.ctx.currentCFG(), getLocation(ctx), left, right));
 
 			// Python in (in)
 			else if (operator.IN() != null)
-				result = new PyIn(currentCFG, getLocation(ctx), left, right);
+				result = new PyIn(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python is not (is not) — must be checked before plain IS
 			if (operator.IS() != null && operator.NOT() != null)
-				result = new Not(currentCFG, getLocation(ctx),
-						new PyIs(currentCFG, getLocation(ctx), left, right));
+				result = new Not(this.ctx.currentCFG(), getLocation(ctx),
+						new PyIs(this.ctx.currentCFG(), getLocation(ctx), left, right));
 
 			// Python is (is)
 			else if (operator.IS() != null)
-				result = new PyIs(currentCFG, getLocation(ctx), left, right);
+				result = new PyIs(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python less (<)
 			if (operator.LESS_THAN() != null)
-				result = new PyLessThan(currentCFG, getLocation(ctx), left, right);
+				result = new PyLessThan(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python less equal (<=)
 			if (operator.LT_EQ() != null)
-				result = new PyLessOrEqual(currentCFG, getLocation(ctx), left, right);
+				result = new PyLessOrEqual(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python not equals (<>)
 			if (operator.NOT_EQ_1() != null)
-				result = new PyNotEqual(currentCFG, getLocation(ctx), left, right);
+				result = new PyNotEqual(this.ctx.currentCFG(), getLocation(ctx), left, right);
 
 			// Python not equals (!=)
 			if (operator.NOT_EQ_2() != null)
-				result = new PyNotEqual(currentCFG, getLocation(ctx), left, right);
+				result = new PyNotEqual(this.ctx.currentCFG(), getLocation(ctx), left, right);
 			break;
 		}
 
@@ -464,17 +472,17 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (nShift == 1)
 			return visitRight_shift(ctx.right_shift());
 		else if (nShift == 2)
-			return new PyBitwiseLeftShift(currentCFG, getLocation(ctx),
+			return new PyBitwiseLeftShift(this.ctx.currentCFG(), getLocation(ctx),
 					visitRight_shift(ctx.right_shift()),
 					visitLeft_shift(ctx.left_shift(0)));
 		else {
-			Expression temp = new PyBitwiseLeftShift(currentCFG, getLocation(ctx),
+			Expression temp = new PyBitwiseLeftShift(this.ctx.currentCFG(), getLocation(ctx),
 					visitLeft_shift(ctx.left_shift(nShift - 3)),
 					visitLeft_shift(ctx.left_shift(nShift - 2)));
 			nShift = nShift - 2;
 			// concatenate all the Shift expressions together
 			while (nShift > 0) {
-				temp = new PyBitwiseLeftShift(currentCFG, getLocation(ctx),
+				temp = new PyBitwiseLeftShift(this.ctx.currentCFG(), getLocation(ctx),
 						visitLeft_shift(ctx.left_shift(--nShift - 1)),
 						temp);
 			}
@@ -489,17 +497,17 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (nShift == 1)
 			return visitArith_expr(ctx.arith_expr());
 		else if (nShift == 2)
-			return new PyBitwiseRIghtShift(currentCFG, getLocation(ctx),
+			return new PyBitwiseRIghtShift(this.ctx.currentCFG(), getLocation(ctx),
 					visitArith_expr(ctx.arith_expr()),
 					visitRight_shift(ctx.right_shift(0)));
 		else {
-			Expression temp = new PyBitwiseRIghtShift(currentCFG, getLocation(ctx),
+			Expression temp = new PyBitwiseRIghtShift(this.ctx.currentCFG(), getLocation(ctx),
 					visitRight_shift(ctx.right_shift(nShift - 3)),
 					visitRight_shift(ctx.right_shift(nShift - 2)));
 			nShift = nShift - 2;
 			// concatenate all the Shift expressions together
 			while (nShift > 0) {
-				temp = new PyBitwiseRIghtShift(currentCFG, getLocation(ctx),
+				temp = new PyBitwiseRIghtShift(this.ctx.currentCFG(), getLocation(ctx),
 						visitRight_shift(ctx.right_shift(--nShift - 1)),
 						temp);
 			}
@@ -525,7 +533,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.arith_expr() == null)
 			return visitTerm(ctx.term());
 		else
-			return new Subtraction(currentCFG, getLocation(ctx),
+			return new Subtraction(this.ctx.currentCFG(), getLocation(ctx),
 					visitTerm(ctx.term()),
 					visitArith_expr(ctx.arith_expr()));
 	}
@@ -536,7 +544,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.arith_expr() == null)
 			return visitTerm(ctx.term());
 		else
-			return new PyAddition(currentCFG, getLocation(ctx),
+			return new PyAddition(this.ctx.currentCFG(), getLocation(ctx),
 					visitTerm(ctx.term()),
 					visitArith_expr(ctx.arith_expr()));
 	}
@@ -566,7 +574,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.term() == null)
 			return visitFactor(ctx.factor());
 		else
-			return new PyMultiplication(currentCFG, getLocation(ctx),
+			return new PyMultiplication(this.ctx.currentCFG(), getLocation(ctx),
 					visitFactor(ctx.factor()),
 					visitTerm(ctx.term()));
 	}
@@ -576,7 +584,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.term() == null)
 			return visitFactor(ctx.factor());
 		else
-			return new PyMatMul(currentCFG, getLocation(ctx),
+			return new PyMatMul(this.ctx.currentCFG(), getLocation(ctx),
 					visitFactor(ctx.factor()),
 					visitTerm(ctx.term()));
 	}
@@ -586,7 +594,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.term() == null)
 			return visitFactor(ctx.factor());
 		else
-			return new Division(currentCFG, getLocation(ctx),
+			return new Division(this.ctx.currentCFG(), getLocation(ctx),
 					visitFactor(ctx.factor()),
 					visitTerm(ctx.term()));
 	}
@@ -596,7 +604,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.term() == null)
 			return visitFactor(ctx.factor());
 		else
-			return new PyRemainder(currentCFG, getLocation(ctx),
+			return new PyRemainder(this.ctx.currentCFG(), getLocation(ctx),
 					visitFactor(ctx.factor()),
 					visitTerm(ctx.term()));
 	}
@@ -606,7 +614,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.term() == null)
 			return visitFactor(ctx.factor());
 		else
-			return new PyFloorDiv(currentCFG, getLocation(ctx),
+			return new PyFloorDiv(this.ctx.currentCFG(), getLocation(ctx),
 					visitFactor(ctx.factor()),
 					visitTerm(ctx.term()));
 	}
@@ -617,11 +625,11 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (ctx.power() != null)
 			return visitPower(ctx.power());
 		else if (ctx.NOT_OP() != null)
-			return new PyBitwiseNot(currentCFG, getLocation(ctx),
+			return new PyBitwiseNot(this.ctx.currentCFG(), getLocation(ctx),
 					visitFactor(ctx.factor()));
 		else if (ctx.MINUS() != null)
-			return new PyMultiplication(currentCFG, getLocation(ctx),
-					new Int32Literal(currentCFG, getLocation(ctx), -1),
+			return new PyMultiplication(this.ctx.currentCFG(), getLocation(ctx),
+					new Int32Literal(this.ctx.currentCFG(), getLocation(ctx), -1),
 					visitFactor(ctx.factor()));
 		return visitFactor(ctx.factor());
 	}
@@ -630,7 +638,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 	public Expression visitPower(
 			PowerContext ctx) {
 		if (ctx.POWER() != null)
-			return new PyPower(currentCFG, getLocation(ctx),
+			return new PyPower(this.ctx.currentCFG(), getLocation(ctx),
 					visitAtom_expr(ctx.atom_expr()),
 					visitFactor(ctx.factor()));
 		else
@@ -641,18 +649,18 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 	public Expression visitArgument(
 			ArgumentContext ctx) {
 		if (ctx.ASSIGN() != null) {
-			boolean prevShouldPrependUnitAccess = shouldPrependUnitAccess;
-			shouldPrependUnitAccess = false;
+			boolean prevShouldPrependUnitAccess = this.ctx.shouldPrependUnitAccess();
+			this.ctx.shouldPrependUnitAccess(false);
 			Expression left = visitTest(ctx.test(0));
-			shouldPrependUnitAccess = prevShouldPrependUnitAccess;
+			this.ctx.shouldPrependUnitAccess(prevShouldPrependUnitAccess);
 			Expression right = visitTest(ctx.test(1));
-			return new PyAssign(currentCFG, getLocation(ctx), left, right);
+			return new PyAssign(this.ctx.currentCFG(), getLocation(ctx), left, right);
 		}
 
 		else if (ctx.STAR() != null)
-			return new StarExpression(currentCFG, getLocation(ctx), visitTest(ctx.test(0)));
+			return new StarExpression(this.ctx.currentCFG(), getLocation(ctx), visitTest(ctx.test(0)));
 		else if (ctx.comp_for() != null || ctx.POWER() != null || ctx.test().size() != 1)
-			return new Empty(currentCFG, getLocation(ctx));
+			return new Empty(this.ctx.currentCFG(), getLocation(ctx));
 		// throw new UnsupportedStatementException("We support only simple
 		// arguments in method calls");
 		// return null;
@@ -673,7 +681,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 			List<Expression> values = new ArrayList<>();
 			for (TestContext exp : ctx.test())
 				values.add(visitTest(exp));
-			return new SetCreation(currentCFG, getLocation(ctx), values.toArray(Expression[]::new));
+			return new SetCreation(this.ctx.currentCFG(), getLocation(ctx), values.toArray(Expression[]::new));
 		} else
 			throw new UnsupportedStatementException();
 	}
@@ -683,13 +691,14 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 			Subscript_Context ctx) {
 		if (ctx.COLON() != null) {
 			SourceCodeLocation loc = getLocation(ctx);
-			Expression left = ctx.test1() == null ? new Empty(currentCFG, loc)
+			Expression left = ctx.test1() == null ? new Empty(this.ctx.currentCFG(), loc)
 					: visitTest(ctx.test1().test());
-			Expression middle = ctx.test2() == null ? new Empty(currentCFG, loc)
+			Expression middle = ctx.test2() == null ? new Empty(this.ctx.currentCFG(), loc)
 					: visitTest(ctx.test2().test());
-			Expression right = ctx.sliceop() == null || ctx.sliceop().test() == null ? new Empty(currentCFG, loc)
+			Expression right = ctx.sliceop() == null || ctx.sliceop().test() == null
+					? new Empty(this.ctx.currentCFG(), loc)
 					: visitTest(ctx.sliceop().test());
-			return new RangeValue(currentCFG, loc, left, middle, right);
+			return new RangeValue(this.ctx.currentCFG(), loc, left, middle, right);
 		} else
 			return visitTest(ctx.test());
 	}
@@ -777,21 +786,21 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 	 * function being parsed, or {@code null} if the current function is not
 	 * defined inside a Python class (e.g. it is a module-level function).
 	 * <p>
-	 * During method-body parsing, {@code currentUnit} is the
+	 * During method-body parsing, {@code this.ctx.currentUnit()} is the
 	 * {@link it.unive.pylisa.program.FunctionUnit} for the method, not the
 	 * enclosing class. The enclosing class name is the prefix obtained by
 	 * stripping the last {@code ".<methodName>"} component from the function
-	 * unit name. The class is then looked up from the LiSA program.
+	 * unit name. The class is then looked up from the LiSA this.ctx.program().
 	 *
 	 * @return the enclosing {@link PyClassUnit}, or {@code null}
 	 */
 	protected PyClassUnit findEnclosingPyClassUnit() {
-		String funcName = currentUnit.getName();
+		String funcName = this.ctx.currentUnit().getName();
 		int lastDot = funcName.lastIndexOf('.');
 		if (lastDot <= 0)
 			return null;
 		String classUnitName = funcName.substring(0, lastDot);
-		it.unive.lisa.program.Unit candidate = program.getUnit(classUnitName);
+		it.unive.lisa.program.Unit candidate = this.ctx.program().getUnit(classUnitName);
 		log.debug("findEnclosingPyClassUnit: funcName='{}', classUnitName='{}', candidate={}",
 				funcName, classUnitName, candidate == null ? "null" : candidate.getName());
 		if (candidate instanceof PyClassUnit pcu)
@@ -806,7 +815,7 @@ public abstract class PyExpressionVisitorBase extends PyFrontendBase {
 		if (names.size() == 0)
 			return result;
 		for (VfpdefContext e : names)
-			result.add(new VariableRef(currentCFG, getLocation(e), (String) visitVfpdef(e)));
+			result.add(new VariableRef(this.ctx.currentCFG(), getLocation(e), (String) visitVfpdef(e)));
 		return result;
 	}
 }

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/PyFrontend.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/PyFrontend.java
@@ -57,10 +57,10 @@ import org.apache.commons.lang3.tuple.Triple;
 public class PyFrontend extends PyDefinitionVisitorBase {
 
 	/**
-	 * Builds an instance of @PyFrontend for a given Python program given at the
-	 * location filePath.
+	 * Builds an instance of @PyFrontend for a given Python this.ctx.program()
+	 * given at the location filePath.
 	 *
-	 * @param filePath file path to a Python program
+	 * @param filePath file path to a Python this.ctx.program()
 	 * @param notebook whether or not {@code filePath} points to a Jupyter
 	 *                     notebook file
 	 */
@@ -71,10 +71,10 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 	}
 
 	/**
-	 * Builds an instance of @PyFrontend for a given Python program given at the
-	 * location filePath.
+	 * Builds an instance of @PyFrontend for a given Python this.ctx.program()
+	 * given at the location filePath.
 	 *
-	 * @param filePath  file path to a Python program
+	 * @param filePath  file path to a Python this.ctx.program()
 	 * @param notebook  whether or not {@code filePath} points to a Jupyter
 	 *                      notebook file
 	 * @param cellOrder sequence of the indexes of cells of a Jupyter notebook
@@ -89,10 +89,10 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 	}
 
 	/**
-	 * Builds an instance of @PyFrontend for a given Python program given at the
-	 * location filePath.
+	 * Builds an instance of @PyFrontend for a given Python this.ctx.program()
+	 * given at the location filePath.
 	 *
-	 * @param filePath  file path to a Python program
+	 * @param filePath  file path to a Python this.ctx.program()
 	 * @param notebook  whether or not {@code filePath} points to a Jupyter
 	 *                      notebook file
 	 * @param cellOrder list of the indexes of cells of a Jupyter notebook in
@@ -107,15 +107,16 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 	}
 
 	/**
-	 * Builds an instance of @PyFrontend for a given Python program given at the
-	 * location filePath, with an explicit source root for module resolution.
+	 * Builds an instance of @PyFrontend for a given Python this.ctx.program()
+	 * given at the location filePath, with an explicit source root for module
+	 * resolution.
 	 *
-	 * @param filePath   file path to a Python program
+	 * @param filePath   file path to a Python this.ctx.program()
 	 * @param notebook   whether or not {@code filePath} points to a Jupyter
 	 *                       notebook file
 	 * @param sourceRoot explicit root directory for resolving project-relative
-	 *                       imports; if {@code null}, defaults to the parent of
-	 *                       {@code filePath}
+	 *                       this.ctx.imports(); if {@code null}, defaults to
+	 *                       the parent of {@code filePath}
 	 */
 	public PyFrontend(
 			String filePath,
@@ -125,14 +126,15 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 	}
 
 	/**
-	 * Returns the collection of @CFG in a Python program at filePath.
+	 * Returns the collection of @CFG in a Python this.ctx.program() at
+	 * filePath.
 	 *
 	 * @return collection of @CFG in file
 	 *
 	 * @throws IOException            if {@code stream} to file cannot be read
 	 *                                    from or closed
 	 * @throws AnalysisSetupException if something goes wrong while setting up
-	 *                                    the program
+	 *                                    the this.ctx.program()
 	 */
 	public Program toLiSAProgram(
 			boolean clearClassType)
@@ -143,10 +145,10 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 			PyFunctionType.clearAll();
 			PyModuleType.clearAll();
 			// Re-register __main__ which was set up in the constructor
-			PyModuleType.register(currentModule.getName(), currentModule);
+			PyModuleType.register(this.ctx.currentModule().getName(), this.ctx.currentModule());
 		}
 
-		TypeSystem types = program.getTypes();
+		TypeSystem types = this.ctx.program().getTypes();
 		types.registerType(PyLambdaType.INSTANCE);
 		types.registerType(BoolType.INSTANCE);
 		types.registerType(StringType.INSTANCE);
@@ -155,16 +157,16 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 		types.registerType(NullType.INSTANCE);
 		types.registerType(VoidType.INSTANCE);
 		types.registerType(Untyped.INSTANCE);
-		LibrarySpecificationProvider.load(program, init);
+		LibrarySpecificationProvider.load(this.ctx.program(), init);
 
-		LibrarySpecificationProvider.importPythonModule(program, "builtins", init);
-		objectUnit = (it.unive.lisa.program.CompilationUnit) program.getUnit("builtins.object");
-		if (objectUnit == null)
+		LibrarySpecificationProvider.importPythonModule(this.ctx.program(), "builtins", init);
+		this.ctx.objectUnit((it.unive.lisa.program.CompilationUnit) this.ctx.program().getUnit("builtins.object"));
+		if (this.ctx.objectUnit() == null)
 			log.warn("Could not resolve 'builtins.object' after library loading; "
 					+ "classes without explicit parents will have no ancestor");
 		log.info("Reading file... " + filePath);
 
-		importManager.setProjectLoader(this::loadProjectModuleFile);
+		this.ctx.importManager().setProjectLoader(this::loadProjectModuleFile);
 
 		String source;
 		Python3Lexer lexer;
@@ -182,9 +184,9 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 		PyClassType.all().forEach(types::registerType);
 		ModuleUnit pyProgramUnit = new ModuleUnit(
 				new SourceCodeLocation("__lisa__", 0, 0),
-				program,
+				this.ctx.program(),
 				"$PythonProgram");
-		program.addUnit(pyProgramUnit);
+		this.ctx.program().addUnit(pyProgramUnit);
 		CodeMemberDescriptor runDesc = new CodeMemberDescriptor(new SourceCodeLocation("__lisa__", 0, 0), pyProgramUnit,
 				false, "run");
 		runDesc.setOverridable(false);
@@ -200,8 +202,8 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 		Ret ret = new Ret(runCFG, SyntheticLocation.INSTANCE);
 		runCFG.addNode(ret);
 		runCFG.addEdge(new SequentialEdge(importModuleMain, ret));
-		program.addEntryPoint(runCFG);
-		return program;
+		this.ctx.program().addEntryPoint(runCFG);
+		return this.ctx.program();
 	}
 
 	public Program toLiSAProgram() throws IOException, AnalysisSetupException {
@@ -213,22 +215,22 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 			String filePath)
 			throws IOException {
 		// Save current state
-		ModuleUnit savedModule = currentModule;
-		Unit savedUnit = currentUnit;
-		PyCFG savedCFG = currentCFG;
-		Map<String, String> savedImports = imports;
-		Collection<ControlFlowStructure> savedCfs = cfs;
-		boolean savedShouldPrependUnitAccess = shouldPrependUnitAccess;
+		ModuleUnit savedModule = this.ctx.currentModule();
+		Unit savedUnit = this.ctx.currentUnit();
+		PyCFG savedCFG = this.ctx.currentCFG();
+		Map<String, String> savedImports = this.ctx.imports();
+		Collection<ControlFlowStructure> savedCfs = this.ctx.cfs();
+		boolean savedShouldPrependUnitAccess = this.ctx.shouldPrependUnitAccess();
 		boolean savedFileIsPackage = currentFileIsPackage;
 		currentFileIsPackage = filePath.endsWith("__init__.py");
 
 		// The ModuleUnit was already registered by loadProjectModule before
 		// calling us
 		ModuleUnit newModule = (ModuleUnit) PyModuleType.lookup(moduleName).getUnit();
-		currentModule = newModule;
-		currentUnit = newModule;
-		imports = new HashMap<>();
-		cfs = new HashSet<>();
+		this.ctx.currentModule(newModule);
+		this.ctx.currentUnit(newModule);
+		this.ctx.imports(new HashMap<>());
+		this.ctx.cfs(new HashSet<>());
 
 		boolean savedContinue = continueOnUnsupportedStatement;
 		continueOnUnsupportedStatement = true; // resilient for sub-module loads
@@ -244,12 +246,12 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 		} finally {
 			continueOnUnsupportedStatement = savedContinue;
 			// Always restore state, even if parsing fails
-			currentModule = savedModule;
-			currentUnit = savedUnit;
-			currentCFG = savedCFG;
-			imports = savedImports;
-			cfs = savedCfs;
-			shouldPrependUnitAccess = savedShouldPrependUnitAccess;
+			this.ctx.currentModule(savedModule);
+			this.ctx.currentUnit(savedUnit);
+			this.ctx.currentCFG(savedCFG);
+			this.ctx.imports(savedImports);
+			this.ctx.cfs(savedCfs);
+			this.ctx.shouldPrependUnitAccess(savedShouldPrependUnitAccess);
 			currentFileIsPackage = savedFileIsPackage;
 		}
 
@@ -276,19 +278,20 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 	public PyCFG visitFile_input(
 			File_inputContext ctx) {
 
-		currentCFG = new PyCFG(buildInitModuleCFGDescriptor(getLocation(ctx)));
-		ImportModule builtinsModule = new ImportModule(currentCFG, getLocation(ctx), "builtins",
+		this.ctx.currentCFG(new PyCFG(buildInitModuleCFGDescriptor(getLocation(ctx))));
+		ImportModule builtinsModule = new ImportModule(this.ctx.currentCFG(), getLocation(ctx), "builtins",
 				PyModuleType.lookup("builtins").getUnit());
-		currentCFG.addNode(builtinsModule, true);
-		cfs = new HashSet<>();
-		currentModule.addCodeMember(currentCFG);
-		Expression targetName = new PythonScopedAttributeAccessRef(this.currentCFG, getLocation(ctx), currentModule,
-				new Global(getLocation(ctx), currentModule, "__name__", false));
+		this.ctx.currentCFG().addNode(builtinsModule, true);
+		this.ctx.cfs(new HashSet<>());
+		this.ctx.currentModule().addCodeMember(this.ctx.currentCFG());
+		Expression targetName = new PythonScopedAttributeAccessRef(this.ctx.currentCFG(), getLocation(ctx),
+				this.ctx.currentModule(),
+				new Global(getLocation(ctx), this.ctx.currentModule(), "__name__", false));
 
-		PyAssign nameAssign = new PyAssign(this.currentCFG, getLocation(ctx), targetName,
-				new StringLiteral(this.currentCFG, getLocation(ctx), currentModule.getName()));
-		currentCFG.addNode(nameAssign);
-		currentCFG.addEdge(new SequentialEdge(builtinsModule, nameAssign));
+		PyAssign nameAssign = new PyAssign(this.ctx.currentCFG(), getLocation(ctx), targetName,
+				new StringLiteral(this.ctx.currentCFG(), getLocation(ctx), this.ctx.currentModule().getName()));
+		this.ctx.currentCFG().addNode(nameAssign);
+		this.ctx.currentCFG().addEdge(new SequentialEdge(builtinsModule, nameAssign));
 		Statement lastStmt = nameAssign;
 		for (StmtContext stmt : IterationLogger.iterate(log, ctx.stmt(), "Parsing stmt lists...", "Global stmt")) {
 			Object visited;
@@ -312,19 +315,19 @@ public class PyFrontend extends PyDefinitionVisitorBase {
 			@SuppressWarnings("unchecked")
 			Triple<Statement, NodeList<CFG, Statement, Edge>,
 					Statement> st = (Triple<Statement, NodeList<CFG, Statement, Edge>, Statement>) visited;
-			currentCFG.getNodeList().mergeWith(st.getMiddle());
+			this.ctx.currentCFG().getNodeList().mergeWith(st.getMiddle());
 			if (lastStmt == null)
 				// this is the first instruction
-				currentCFG.getEntrypoints().add(st.getLeft());
+				this.ctx.currentCFG().getEntrypoints().add(st.getLeft());
 			else if (!lastStmt.stopsExecution())
-				currentCFG.addEdge(new SequentialEdge(lastStmt, st.getLeft()));
+				this.ctx.currentCFG().addEdge(new SequentialEdge(lastStmt, st.getLeft()));
 			lastStmt = st.getRight();
 		}
 
 		addRetNodesToCurrentCFG();
-		cfs.forEach(currentCFG.getDescriptor()::addControlFlowStructure);
-		currentCFG.simplify();
-		return currentCFG;
+		this.ctx.cfs().forEach(this.ctx.currentCFG().getDescriptor()::addControlFlowStructure);
+		this.ctx.currentCFG().simplify();
+		return this.ctx.currentCFG();
 	}
 
 	@Override

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/PyFrontendBase.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/PyFrontendBase.java
@@ -36,17 +36,11 @@ import it.unive.pylisa.cfg.type.PyModuleType;
 import it.unive.pylisa.program.FunctionUnit;
 import it.unive.pylisa.program.ModuleUnit;
 import java.nio.file.Path;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -62,43 +56,20 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 
 	protected static final Logger log = LogManager.getLogger(PyFrontendBase.class);
 
-	protected Map<String, String> imports = new HashMap<>();
+	/**
+	 * Mutable parsing state shared across every visitor. Introduced in Chunk 1
+	 * of the front-end refactor; replaces the protected fields that used to
+	 * live here and leak across the four-level inheritance chain.
+	 */
+	protected final ParserContext ctx = new ParserContext();
+
 	/**
 	 * Python program file path.
 	 */
 	protected final String filePath;
 
-	protected boolean shouldPrependUnitAccess = true;
 	protected boolean currentFileIsPackage = false;
 	protected CFG init;
-	/**
-	 * The LiSA program obtained from the Python program at filePath.
-	 */
-	protected final Program program;
-	protected final PythonModuleImportManager importManager;
-	/**
-	 * The module currently under parsing
-	 */
-	protected ModuleUnit currentModule;
-	protected it.unive.lisa.program.CompilationUnit objectUnit;
-
-	/**
-	 * The unit currently under parsing
-	 */
-	protected Unit currentUnit;
-	/**
-	 * Current CFG to parse
-	 */
-	protected PyCFG currentCFG;
-
-	protected Collection<ControlFlowStructure> cfs;
-
-	/**
-	 * Stack of local scopes used to resolve Python names with LEGB-like
-	 * precedence. Module/class names are represented with scoped attribute
-	 * accesses, while names in this stack stay as variable references.
-	 */
-	private final Deque<Set<String>> localScopes = new ArrayDeque<>();
 
 	/**
 	 * Whether or not {@link #filePath} points to a Jupyter notebook file
@@ -194,21 +165,21 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 			boolean notebook,
 			List<Integer> cellOrder,
 			String sourceRoot) {
-		this.program = new Program(new PythonFeatures(), new PythonTypeSystem());
+		ctx.program(new Program(new PythonFeatures(), new PythonTypeSystem()));
 		this.filePath = filePath;
 		this.notebook = notebook;
 		this.cellOrder = cellOrder;
 		this.currentFileIsPackage = (filePath != null && filePath.endsWith("__init__.py"));
-		this.currentModule = new ModuleUnit(new SourceCodeLocation(filePath, 0, 0),
-				program, "__main__");
-		this.currentUnit = currentModule;
-		makeInit(program);
+		ctx.currentModule(new ModuleUnit(new SourceCodeLocation(filePath, 0, 0),
+				ctx.program(), "__main__"));
+		ctx.currentUnit(ctx.currentModule());
+		makeInit(ctx.program());
 		Path baseDir = (sourceRoot != null)
 				? Path.of(sourceRoot)
 				: (filePath != null) ? Path.of(filePath).getParent() : Path.of(".");
-		this.importManager = new PythonModuleImportManager(program, init, baseDir);
-		program.addUnit(currentModule);
-		PyModuleType.register("__main__", currentModule);
+		ctx.importManager(new PythonModuleImportManager(ctx.program(), init, baseDir));
+		ctx.program().addUnit(ctx.currentModule());
+		PyModuleType.register("__main__", ctx.currentModule());
 	}
 
 	/**
@@ -237,8 +208,8 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 	protected Expression makeRef(
 			String name,
 			CodeLocation loc) {
-		if (!shouldPrependUnitAccess)
-			return new VariableRef(currentCFG, loc, name);
+		if (!ctx.shouldPrependUnitAccess())
+			return new VariableRef(ctx.currentCFG(), loc, name);
 
 		// ── CASE 1: Inside a function / method body
 		// ────────────────────────────
@@ -247,13 +218,13 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 		// of LEGB — a bare name in a method does NOT see class attributes.
 		// E = enclosing function scopes — NOT YET IMPLEMENTED (future work).
 		// G = module (global) scope — the fallback when not found locally.
-		if (currentUnit instanceof FunctionUnit) {
+		if (ctx.currentUnit() instanceof FunctionUnit) {
 			if (isNameInTopLocalScope(name))
-				return new VariableRef(currentCFG, loc, name);
+				return new VariableRef(ctx.currentCFG(), loc, name);
 			// Not in local scope: fall through to module (G) with B fallback.
-			if (currentModule != null)
+			if (ctx.currentModule() != null)
 				return makeNameRef(name, loc);
-			return new VariableRef(currentCFG, loc, name);
+			return new VariableRef(ctx.currentCFG(), loc, name);
 		}
 
 		// ── CASE 2: Inside a class body (not inside a method)
@@ -263,78 +234,71 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 		// the class body frame (method scope is only pushed by visitFuncdef,
 		// which changes currentUnit to FunctionUnit before pushing).
 		// Class-body names map to class-scoped attribute references.
-		if (currentUnit instanceof ClassUnit cu) {
+		if (ctx.currentUnit() instanceof ClassUnit cu) {
 			if (isNameInVisibleLocalScope(name))
 				return makeScopedAttributeRef(cu, name, loc);
-			if (currentModule != null)
+			if (ctx.currentModule() != null)
 				return makeNameRef(name, loc);
-			return new VariableRef(currentCFG, loc, name);
+			return new VariableRef(ctx.currentCFG(), loc, name);
 		}
 
 		// ── CASE 3: Module-level code (ModuleUnit extends CompilationUnit)
 		// ─────
 		if (isNameInVisibleLocalScope(name)) {
-			if (currentUnit instanceof CompilationUnit cu)
+			if (ctx.currentUnit() instanceof CompilationUnit cu)
 				return makeScopedAttributeRef(cu, name, loc);
-			return new VariableRef(currentCFG, loc, name);
+			return new VariableRef(ctx.currentCFG(), loc, name);
 		}
 
-		if (currentUnit instanceof CompilationUnit)
+		if (ctx.currentUnit() instanceof CompilationUnit)
 			return makeNameRef(name, loc);
 
-		if (currentModule != null)
+		if (ctx.currentModule() != null)
 			return makeNameRef(name, loc);
 
-		return new VariableRef(currentCFG, loc, name);
+		return new VariableRef(ctx.currentCFG(), loc, name);
 	}
 
 	protected Expression makeScopedAttributeRef(
 			CompilationUnit unit,
 			String name,
 			CodeLocation loc) {
-		return new PythonScopedAttributeAccessRef(currentCFG, loc, unit,
+		return new PythonScopedAttributeAccessRef(ctx.currentCFG(), loc, unit,
 				new Global(loc, unit, name, false));
 	}
 
 	protected Expression makeNameRef(
 			String name,
 			CodeLocation loc) {
-		String modName = (currentModule != null) ? currentModule.getName() : "__main__";
+		String modName = (ctx.currentModule() != null) ? ctx.currentModule().getName() : "__main__";
 		// Parse-time hint: if the current module recorded a
 		// `from <X> import <name>` (or `... as name`) binding, pass the
 		// qualified name (e.g. "fastapi.APIRouter") to PyNameRef for use
 		// as a fallback when runtime-scope lookup fails.
-		String qualified = (imports != null) ? imports.get(name) : null;
-		return new it.unive.pylisa.cfg.statement.PyNameRef(currentCFG, loc, name, modName, qualified);
+		String qualified = (ctx.imports() != null) ? ctx.imports().get(name) : null;
+		return new it.unive.pylisa.cfg.statement.PyNameRef(ctx.currentCFG(), loc, name, modName, qualified);
 	}
 
 	protected void enterLocalScope() {
-		localScopes.push(new HashSet<>());
+		ctx.enterLocalScope();
 	}
 
 	protected void exitLocalScope() {
-		if (!localScopes.isEmpty())
-			localScopes.pop();
+		ctx.exitLocalScope();
 	}
 
 	protected boolean isInsideLocalScope() {
-		return !localScopes.isEmpty();
+		return ctx.isInsideLocalScope();
 	}
 
 	protected void declareNameInCurrentScope(
 			String name) {
-		if (!localScopes.isEmpty() && name != null && !name.isEmpty())
-			localScopes.peek().add(name);
+		ctx.declareNameInCurrentScope(name);
 	}
 
 	protected boolean isNameInVisibleLocalScope(
 			String name) {
-		if (name == null || name.isEmpty())
-			return false;
-		for (Set<String> scope : localScopes)
-			if (scope.contains(name))
-				return true;
-		return false;
+		return ctx.isNameInVisibleLocalScope(name);
 	}
 
 	/**
@@ -344,15 +308,12 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 	 * enclosing class-body scope frames are intentionally excluded.
 	 *
 	 * @param name the name to look up
-	 * 
+	 *
 	 * @return {@code true} if {@code name} is in the top scope frame
 	 */
 	protected boolean isNameInTopLocalScope(
 			String name) {
-		if (name == null || name.isEmpty())
-			return false;
-		Set<String> top = localScopes.peek();
-		return top != null && top.contains(name);
+		return ctx.isNameInTopLocalScope(name);
 	}
 
 	@FunctionalInterface
@@ -372,10 +333,10 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 		int n = operands.size();
 		if (n == 1)
 			return sub.apply(operands.get(0));
-		Expression acc = factory.make(currentCFG, loc,
+		Expression acc = factory.make(ctx.currentCFG(), loc,
 				sub.apply(operands.get(n - 2)), sub.apply(operands.get(n - 1)));
 		for (int i = n - 3; i >= 0; i--)
-			acc = factory.make(currentCFG, loc, sub.apply(operands.get(i)), acc);
+			acc = factory.make(ctx.currentCFG(), loc, sub.apply(operands.get(i)), acc);
 		return acc;
 	}
 
@@ -417,19 +378,19 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 	protected CodeMemberDescriptor buildMainCFGDescriptor(
 			SourceCodeLocation loc) {
 		PyParameter[] cfgArgs = new PyParameter[] {};
-		return new CodeMemberDescriptor(loc, currentModule, false, INSTRUMENTED_MAIN_FUNCTION_NAME, cfgArgs);
+		return new CodeMemberDescriptor(loc, ctx.currentModule(), false, INSTRUMENTED_MAIN_FUNCTION_NAME, cfgArgs);
 	}
 
 	protected CodeMemberDescriptor buildInitModuleCFGDescriptor(
 			SourceCodeLocation loc) {
 		PyParameter[] cfgArgs = new PyParameter[] {};
-		return new CodeMemberDescriptor(loc, currentModule, false, "$init", cfgArgs);
+		return new CodeMemberDescriptor(loc, ctx.currentModule(), false, "$init", cfgArgs);
 	}
 
 	protected CodeMemberDescriptor buildInitClassCFGDescriptor(
 			CodeLocation loc) {
 		PyParameter[] cfgArgs = new PyParameter[] {};
-		return new CodeMemberDescriptor(loc, currentUnit, false, "$init", cfgArgs);
+		return new CodeMemberDescriptor(loc, ctx.currentUnit(), false, "$init", cfgArgs);
 	}
 
 	protected CodeMemberDescriptor buildCFGDescriptor(
@@ -444,6 +405,7 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 	}
 
 	protected void addRetNodesToCurrentCFG() {
+		PyCFG currentCFG = ctx.currentCFG();
 		if (currentCFG.getNodesCount() == 0) {
 			// empty method, so the ret is also the entrypoint
 			currentCFG.addNode(new Ret(currentCFG, currentCFG.getDescriptor().getLocation()), true);
@@ -486,7 +448,7 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 				if (!hasNonRetFollower)
 					currentCFG.addEdge(new SequentialEdge(pred, canonicalRet));
 			}
-			for (ControlFlowStructure cf : cfs)
+			for (ControlFlowStructure cf : ctx.cfs())
 				cf.replace(extra, canonicalRet);
 			currentCFG.getNodeList().removeNode(extra);
 		}
@@ -517,6 +479,7 @@ public abstract class PyFrontendBase extends Python3ParserBaseVisitor<Object> {
 	protected StringLiteral strip(
 			CodeLocation location,
 			String string) {
+		PyCFG currentCFG = ctx.currentCFG();
 		// ', ''', ", """
 		if (string.startsWith("'''") && string.endsWith("'''"))
 			return new PyStringLiteral(currentCFG, location, string.substring(3, string.length() - 3), "'''");

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/PyStatementVisitorBase.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/PyStatementVisitorBase.java
@@ -154,9 +154,9 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		else if (ctx.flow_stmt() != null)
 			return visitFlow_stmt(ctx.flow_stmt());
 		else if (ctx.nonlocal_stmt() != null)
-			return new NoOp(currentCFG, getLocation(ctx)); // TODO
+			return new NoOp(this.ctx.currentCFG(), getLocation(ctx)); // TODO
 		else if (ctx.global_stmt() != null)
-			return new NoOp(currentCFG, getLocation(ctx)); // TODO
+			return new NoOp(this.ctx.currentCFG(), getLocation(ctx)); // TODO
 		throw new UnsupportedStatementException("Simple statement not yet supported");
 	}
 
@@ -164,15 +164,16 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 	public Expression visitExpr_stmt(
 			Expr_stmtContext ctx) {
 		if (ctx.annassign() != null) {
-			boolean oldPrepend = shouldPrependUnitAccess;
-			shouldPrependUnitAccess = false;
+			boolean oldPrepend = this.ctx.shouldPrependUnitAccess();
+			this.ctx.shouldPrependUnitAccess(false);
 			Expression rawTarget = visitTestlist_star_expr(ctx.testlist_star_expr(0));
-			shouldPrependUnitAccess = oldPrepend;
+			this.ctx.shouldPrependUnitAccess(oldPrepend);
 
 			declareAssignedNames(rawTarget);
 			Expression target = scopeAssignmentTarget(rawTarget);
 			if (ctx.annassign().ASSIGN() != null && ctx.annassign().test().size() > 1)
-				return new PyAssign(currentCFG, getLocation(ctx), target, visitTest(ctx.annassign().test(1)));
+				return new PyAssign(this.ctx.currentCFG(), getLocation(ctx), target,
+						visitTest(ctx.annassign().test(1)));
 
 			// Type-only annotations do not carry runtime effects in our current
 			// model.
@@ -186,10 +187,10 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			else
 				return visitTestlist_star_expr(ctx.testlist_star_expr(0));
 
-		boolean oldPrepend = shouldPrependUnitAccess;
-		shouldPrependUnitAccess = false;
+		boolean oldPrepend = this.ctx.shouldPrependUnitAccess();
+		this.ctx.shouldPrependUnitAccess(false);
 		Expression rawTarget = visitTestlist_star_expr(ctx.testlist_star_expr(0));
-		shouldPrependUnitAccess = oldPrepend;
+		this.ctx.shouldPrependUnitAccess(oldPrepend);
 
 		declareAssignedNames(rawTarget);
 		Expression target = scopeAssignmentTarget(rawTarget);
@@ -204,12 +205,12 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			Expression key = fa.getSubExpressions()[2];
 			Expression rhs = visitTestlist_star_expr(ctx.testlist_star_expr(1));
 			Expression setitemAttr = new AttributeAccess(
-					currentCFG, getLocation(ctx), receiver, "__setitem__");
-			return new FunctionApply(currentCFG, getLocation(ctx), setitemAttr,
+					this.ctx.currentCFG(), getLocation(ctx), receiver, "__setitem__");
+			return new FunctionApply(this.ctx.currentCFG(), getLocation(ctx), setitemAttr,
 					new Expression[] { receiver, key, rhs }, true);
 		}
 
-		PyAssign assign = new PyAssign(currentCFG, getLocation(ctx),
+		PyAssign assign = new PyAssign(this.ctx.currentCFG(), getLocation(ctx),
 				target,
 				visitTestlist_star_expr(ctx.testlist_star_expr(1)));
 		return assign;
@@ -243,7 +244,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		if (ctx.exprlist().star_expr().size() > 0)
 			return unsupported(ctx, "We support only expressions without * in del statements");
 		Statement result = new UnresolvedCall(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				CallType.STATIC,
 				Program.PROGRAM_NAME,
@@ -256,7 +257,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 	@Override
 	public Statement visitPass_stmt(
 			Pass_stmtContext ctx) {
-		return new NoOp(currentCFG, getLocation(ctx));
+		return new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 	}
 
 	@Override
@@ -275,7 +276,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 	public Expression visitAssert_stmt(
 			Assert_stmtContext ctx) {
 		return new UnresolvedCall(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				CallType.STATIC,
 				"assert",
@@ -293,7 +294,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 
 		if (ctx.raise_stmt() != null) {
 			unsound(ctx, "raise treated as no-op");
-			return new NoOp(currentCFG, getLocation(ctx));
+			return new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 		}
 
 		if (ctx.yield_stmt() != null) {
@@ -301,11 +302,11 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			if (yieldArg == null) {
 				// bare 'yield' — treat as a no-op (control flow continues to
 				// cleanup code)
-				return new NoOp(currentCFG, getLocation(ctx));
+				return new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 			}
 			List<Expression> l = extractExpressionsFromYieldArg(yieldArg);
 			return new UnresolvedCall(
-					currentCFG,
+					this.ctx.currentCFG(),
 					getLocation(ctx),
 					CallType.STATIC,
 					Program.PROGRAM_NAME,
@@ -327,25 +328,25 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 	public Statement visitReturn_stmt(
 			Return_stmtContext ctx) {
 		if (ctx.testlist() == null)
-			return new Ret(currentCFG, getLocation(ctx));
+			return new Ret(this.ctx.currentCFG(), getLocation(ctx));
 		if (ctx.testlist().test().size() == 1)
-			return new Return(currentCFG, getLocation(ctx), visitTest(ctx.testlist().test(0)));
+			return new Return(this.ctx.currentCFG(), getLocation(ctx), visitTest(ctx.testlist().test(0)));
 		else {
 			unsound(ctx, "multiple return values treated as first value");
-			return new Return(currentCFG, getLocation(ctx), visitTest(ctx.testlist().test(0)));
+			return new Return(this.ctx.currentCFG(), getLocation(ctx), visitTest(ctx.testlist().test(0)));
 		}
 	}
 
 	@Override
 	public Statement visitBreak_stmt(
 			Break_stmtContext ctx) {
-		return new Break(currentCFG, getLocation(ctx));
+		return new Break(this.ctx.currentCFG(), getLocation(ctx));
 	}
 
 	@Override
 	public Statement visitContinue_stmt(
 			Continue_stmtContext ctx) {
-		return new Continue(currentCFG, getLocation(ctx));
+		return new Continue(this.ctx.currentCFG(), getLocation(ctx));
 	}
 
 	@Override
@@ -408,7 +409,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		block.addNode(booleanGuard);
 
 		// Created if exit node
-		NoOp ifExitNode = new NoOp(currentCFG, getLocation(ctx));
+		NoOp ifExitNode = new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 		block.addNode(ifExitNode);
 
 		// Visit if true block
@@ -464,11 +465,11 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 
 		for (int k = branches.size() - 1; k >= 0; k--) {
 			Pair<Statement, Collection<Statement>> branch = branches.get(k);
-			cfs.add(new IfThenElse(currentCFG.getNodeList(), branch.getLeft(), ifExitNode,
+			this.ctx.cfs().add(new IfThenElse(this.ctx.currentCFG().getNodeList(), branch.getLeft(), ifExitNode,
 					branch.getRight(),
 					new HashSet<>(falseStatements)));
 		}
-		cfs.add(new IfThenElse(currentCFG.getNodeList(), booleanGuard, ifExitNode,
+		this.ctx.cfs().add(new IfThenElse(this.ctx.currentCFG().getNodeList(), booleanGuard, ifExitNode,
 				trueBlock.getMiddle().getNodes(),
 				falseStatements));
 		return Triple.of(booleanGuard, block, ifExitNode);
@@ -479,7 +480,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			While_stmtContext ctx) {
 		NodeList<CFG, Statement, Edge> block = new NodeList<>(SEQUENTIAL_SINGLETON);
 		// create and add exit point of while
-		NoOp whileExitNode = new NoOp(currentCFG, getLocation(ctx));
+		NoOp whileExitNode = new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 		block.addNode(whileExitNode);
 
 		Statement condition = visitTest(ctx.test());
@@ -517,7 +518,8 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			firstFollower = whileExitNode;
 		}
 
-		cfs.add(new Loop(currentCFG.getNodeList(), condition, firstFollower, trueBlock.getMiddle().getNodes()));
+		this.ctx.cfs().add(new Loop(this.ctx.currentCFG().getNodeList(), condition, firstFollower,
+				trueBlock.getMiddle().getNodes()));
 		return Triple.of(condition, block, whileExitNode);
 	}
 
@@ -526,7 +528,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			For_stmtContext ctx) {
 		NodeList<CFG, Statement, Edge> block = new NodeList<>(SEQUENTIAL_SINGLETON);
 		// create and add exit point of for
-		NoOp exit = new NoOp(currentCFG, getLocation(ctx));
+		NoOp exit = new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 		block.addNode(exit);
 
 		List<Expression> exprs = visitExprlist(ctx.exprlist());
@@ -534,35 +536,35 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		if (exprs.size() == 1)
 			variable = exprs.get(0);
 		else
-			variable = new TupleCreation(currentCFG, getLocation(ctx), exprs.toArray(Expression[]::new));
+			variable = new TupleCreation(this.ctx.currentCFG(), getLocation(ctx), exprs.toArray(Expression[]::new));
 
 		List<Expression> list = visitTestlist(ctx.testlist());
 		Expression collection = list.iterator().next();
 
 		VariableRef counter = new VariableRef(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				"__counter_location" + getLocation(ctx).getLine(), Int32Type.INSTANCE);
 		Expression[] counter_pars = { collection, counter };
 
 		// counter = 0;
 		Assignment counter_init = new Assignment(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				counter,
-				new Int32Literal(currentCFG, getLocation(ctx), 0));
+				new Int32Literal(this.ctx.currentCFG(), getLocation(ctx), 0));
 		block.addNode(counter_init);
 
 		// counter < collection.size()
 		UnresolvedCall condition = new UnresolvedCall(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				CallType.INSTANCE,
 				null,
 				"__lt__",
 				counter,
 				new UnresolvedCall(
-						currentCFG,
+						this.ctx.currentCFG(),
 						getLocation(ctx),
 						CallType.INSTANCE,
 						null,
@@ -573,11 +575,11 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 
 		// element = collection.at(counter)
 		Assignment element_assignment = new Assignment(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				variable,
 				new UnresolvedCall(
-						currentCFG,
+						this.ctx.currentCFG(),
 						getLocation(ctx),
 						CallType.INSTANCE,
 						null,
@@ -588,15 +590,15 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 
 		// counter = counter + 1;
 		Assignment counter_increment = new Assignment(
-				currentCFG,
+				this.ctx.currentCFG(),
 				getLocation(ctx),
 				counter,
 				new PyAddition(
-						currentCFG,
+						this.ctx.currentCFG(),
 						getLocation(ctx),
 						counter,
 						new Int32Literal(
-								currentCFG,
+								this.ctx.currentCFG(),
 								getLocation(ctx),
 								1)));
 		block.addNode(counter_increment);
@@ -626,7 +628,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		Collection<Statement> nodes = new HashSet<>(body.getMiddle().getNodes());
 		nodes.add(element_assignment);
 		nodes.add(counter_increment);
-		cfs.add(new Loop(currentCFG.getNodeList(), condition, exit, nodes));
+		this.ctx.cfs().add(new Loop(this.ctx.currentCFG().getNodeList(), condition, exit, nodes));
 		return Triple.of(counter_init, block, exit);
 	}
 
@@ -649,8 +651,8 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		// common in package `__init__.py` files.
 		Triple<Statement, NodeList<CFG, Statement, Edge>, Statement> body = visitSuite(ctx.suite(0));
 		NodeList<CFG, Statement, Edge> block = new NodeList<>(SEQUENTIAL_SINGLETON);
-		NoOp entry = new NoOp(currentCFG, getLocation(ctx));
-		NoOp exit = new NoOp(currentCFG, getLocation(ctx));
+		NoOp entry = new NoOp(this.ctx.currentCFG(), getLocation(ctx));
+		NoOp exit = new NoOp(this.ctx.currentCFG(), getLocation(ctx));
 		block.addNode(entry);
 		block.addNode(exit);
 		block.mergeWith(body.getMiddle());
@@ -792,8 +794,8 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		}
 
 		String moduleName = libs.keySet().stream().findFirst().get();
-		ModuleUnit module = importManager.importModule(moduleName);
-		return new ImportModule(currentCFG, getLocation(ctx), moduleName, module);
+		ModuleUnit module = this.ctx.importManager().importModule(moduleName);
+		return new ImportModule(this.ctx.currentCFG(), getLocation(ctx), moduleName, module);
 	}
 
 	@Override
@@ -809,10 +811,11 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		}
 
 		if (ctx.import_as_names() == null) {
-			LibrarySpecificationProvider.importLibrary(program, name, init);
-			PyCFG pyCFG = new PyCFG(new CodeMemberDescriptor(getLocation(ctx), currentUnit, false, "__init__"));
+			LibrarySpecificationProvider.importLibrary(this.ctx.program(), name, init);
+			PyCFG pyCFG = new PyCFG(
+					new CodeMemberDescriptor(getLocation(ctx), this.ctx.currentUnit(), false, "__init__"));
 			pyCFG.addNode(new NoOp(pyCFG, SyntheticLocation.INSTANCE));
-			return new ImportModule(currentCFG, getLocation(ctx), name,
+			return new ImportModule(this.ctx.currentCFG(), getLocation(ctx), name,
 					(ModuleUnit) PyModuleType.lookup(name).getUnit());
 		}
 		Map<String, String> components = new java.util.LinkedHashMap<>();
@@ -820,22 +823,22 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			String importedComponent = single.NAME(0).getSymbol().getText();
 			String alias = single.NAME().size() == 2 ? single.NAME(1).getSymbol().getText() : importedComponent;
 			components.put(importedComponent, alias);
-			imports.put(alias, name + "." + importedComponent);
+			this.ctx.imports().put(alias, name + "." + importedComponent);
 			declareNameInCurrentScope(alias);
 		}
-		importManager.importModule(name);
+		this.ctx.importManager().importModule(name);
 
 		for (Map.Entry<String, String> entry : components.entrySet()) {
 			String qualifiedName = name + "." + entry.getKey();
-			if (importManager.canResolveModule(qualifiedName))
-				importManager.importModule(qualifiedName);
+			if (this.ctx.importManager().canResolveModule(qualifiedName))
+				this.ctx.importManager().importModule(qualifiedName);
 		}
 
-		ModuleUnit currentModuleUnit = (currentUnit instanceof ModuleUnit pmu) ? pmu : null;
+		ModuleUnit currentModuleUnit = (this.ctx.currentUnit() instanceof ModuleUnit pmu) ? pmu : null;
 		List<Pair<String, String>> importPairs = components.entrySet().stream()
 				.map(e -> Pair.of(e.getValue(), e.getKey()))
 				.collect(java.util.stream.Collectors.toList());
-		return new FromImport(currentCFG, getLocation(ctx), currentModuleUnit, name, importPairs);
+		return new FromImport(this.ctx.currentCFG(), getLocation(ctx), currentModuleUnit, name, importPairs);
 	}
 
 	@Override
@@ -873,7 +876,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		for (int i = 0; i < ctx.NAME().size(); i++) {
 			TerminalNode name = ctx.NAME(i);
 			if (targetName != null) {
-				result = new AttributeAccess(currentCFG, getLocation(ctx), result, name.getText());
+				result = new AttributeAccess(this.ctx.currentCFG(), getLocation(ctx), result, name.getText());
 			} else {
 				result = makeRef(name.getText(), getLocation(ctx));
 			}
@@ -885,7 +888,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 	private String resolveRelativeImport(
 			int dotCount,
 			String dottedName) {
-		String moduleName = (currentModule != null) ? currentModule.getName() : "__main__";
+		String moduleName = (this.ctx.currentModule() != null) ? this.ctx.currentModule().getName() : "__main__";
 		String packageName;
 		if (currentFileIsPackage) {
 			packageName = moduleName;
@@ -900,7 +903,7 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 		// the directory chain — use it as the anchor, matching Python's
 		// __package__ behavior for `python -m <pkg>.<mod>` execution.
 		if (packageName.isEmpty()) {
-			String detected = importManager.getPackageName();
+			String detected = this.ctx.importManager().getPackageName();
 			if (detected != null)
 				packageName = detected;
 		}
@@ -941,14 +944,16 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 			Expression receiver = attr.getSubExpression();
 			if (receiver instanceof VariableRef var) {
 				if (isNameInVisibleLocalScope(var.getName()))
-					return new PyAccessInstanceGlobal(currentCFG, attr.getLocation(), receiver, attr.getTarget());
+					return new PyAccessInstanceGlobal(this.ctx.currentCFG(), attr.getLocation(), receiver,
+							attr.getTarget());
 				// Try to resolve receiver as a CompilationUnit (e.g. Class.Y =
 				// 100)
 				String receiverName = var.getName();
-				String fqName = imports.getOrDefault(receiverName,
-						currentModule != null ? currentModule.getName() + "." + receiverName : null);
+				String fqName = this.ctx.imports().getOrDefault(receiverName,
+						this.ctx.currentModule() != null ? this.ctx.currentModule().getName() + "." + receiverName
+								: null);
 				if (fqName != null) {
-					for (Unit u : program.getUnits()) {
+					for (Unit u : this.ctx.program().getUnits()) {
 						if (u instanceof CompilationUnit cu && cu.getName().equals(fqName))
 							return makeScopedAttributeRef(cu, attr.getTarget(), attr.getLocation());
 					}
@@ -957,37 +962,39 @@ public abstract class PyStatementVisitorBase extends PyExpressionVisitorBase {
 				// instance
 				// variable. Wrap it in a scoped ref so the heap domain can
 				// resolve it to the correct heap location.
-				if (currentModule != null) {
-					Expression scopedReceiver = makeScopedAttributeRef(currentModule, receiverName,
+				if (this.ctx.currentModule() != null) {
+					Expression scopedReceiver = makeScopedAttributeRef(this.ctx.currentModule(), receiverName,
 							var.getLocation());
-					return new PyAccessInstanceGlobal(currentCFG, attr.getLocation(), scopedReceiver,
+					return new PyAccessInstanceGlobal(this.ctx.currentCFG(), attr.getLocation(), scopedReceiver,
 							attr.getTarget());
 				}
 			}
 			if (receiver instanceof PythonScopedAttributeAccessRef scopedRef) {
 				String receiverName = scopedRef.getTarget().getName();
-				String fqName = imports.getOrDefault(receiverName,
-						currentModule != null ? currentModule.getName() + "." + receiverName : null);
+				String fqName = this.ctx.imports().getOrDefault(receiverName,
+						this.ctx.currentModule() != null ? this.ctx.currentModule().getName() + "." + receiverName
+								: null);
 				if (fqName != null) {
-					for (Unit u : program.getUnits()) {
+					for (Unit u : this.ctx.program().getUnits()) {
 						if (u instanceof CompilationUnit cu && cu.getName().equals(fqName))
 							return makeScopedAttributeRef(cu, attr.getTarget(), attr.getLocation());
 					}
 				}
 				// Receiver is an instance variable -> instance attribute heap
 				// write
-				return new PyAccessInstanceGlobal(currentCFG, attr.getLocation(), receiver, attr.getTarget());
+				return new PyAccessInstanceGlobal(this.ctx.currentCFG(), attr.getLocation(), receiver,
+						attr.getTarget());
 			}
 			return target;
 		}
 
 		if (target instanceof VariableRef var) {
-			if (isInsideLocalScope() && !(currentUnit instanceof ClassUnit))
+			if (isInsideLocalScope() && !(this.ctx.currentUnit() instanceof ClassUnit))
 				return var;
-			if (currentUnit instanceof CompilationUnit cu)
+			if (this.ctx.currentUnit() instanceof CompilationUnit cu)
 				return makeScopedAttributeRef(cu, var.getName(), var.getLocation());
-			if (currentModule != null)
-				return makeScopedAttributeRef(currentModule, var.getName(), var.getLocation());
+			if (this.ctx.currentModule() != null)
+				return makeScopedAttributeRef(this.ctx.currentModule(), var.getName(), var.getLocation());
 			return var;
 		}
 


### PR DESCRIPTION
Move the 10 mutable parsing fields off PyFrontendBase onto a new ParserContext object and route every read/write through ctx.foo() / ctx.foo(x). Pure plumbing, no logic changes. Unblocks chunk 2 (flatten inheritance).

Fields moved: program, importManager, currentModule, objectUnit, currentUnit, currentCFG, cfs, imports, shouldPrependUnitAccess, localScopes. Scope-stack helpers (enter/exit/isInside/declare/ isNameInVisible/isNameInTop) also migrated; base keeps thin delegators to preserve the subclass-visible API.

./gradlew test: same pass/fail set as chunk-00 baseline (5 pre-existing failures in Classes + Evaluation.functions_redecl, all unchanged).