### PR TITLE
refactor(frontend): chunk 6 — unified diagnostics

### DIFF
--- a/pylisa/src/main/java/it/unive/pylisa/frontend/DiagnosticReporter.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/DiagnosticReporter.java
@@ -1,0 +1,146 @@
+package it.unive.pylisa.frontend;
+
+import it.unive.lisa.program.SourceCodeLocation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Structured diagnostic sink for the PyLiSA front-end. Introduced in Chunk 6 of
+ * the front-end refactor to replace the scattered {@code unsound} and
+ * {@code unsupported} helpers.
+ * <p>
+ * Events are both recorded in memory (for programmatic inspection via
+ * {@link #events()}) and mirrored to log4j at the appropriate level so tests
+ * keep working with {@code LoggerCaptor} and users continue to see them in
+ * console output.
+ * <p>
+ * When constructed in {@code strict} mode, an {@link Severity#UNSOUND} event is
+ * escalated to a {@link StrictModeViolation} after being recorded and logged.
+ * {@link Severity#UNSUPPORTED} events are <em>not</em> auto-thrown — the caller
+ * is expected to follow the
+ * {@link #report(Severity, SourceCodeLocation, String, String)} call with its
+ * own control-flow signal (e.g. throwing
+ * {@link it.unive.pylisa.UnsupportedStatementException}).
+ */
+public final class DiagnosticReporter {
+
+	private static final Logger LOG = LogManager.getLogger(DiagnosticReporter.class);
+
+	/** Severity of a single diagnostic event. */
+	public enum Severity {
+		/** Informational: benign observation, no impact on soundness. */
+		INFO,
+		/**
+		 * Unsound: the frontend approximated or dropped a construct in a way
+		 * that may affect analysis correctness.
+		 */
+		UNSOUND,
+		/** Unsupported: the grammar feature is not yet implemented. */
+		UNSUPPORTED
+	}
+
+	/**
+	 * Immutable record of a single diagnostic occurrence.
+	 *
+	 * @param severity the severity category
+	 * @param location where in the source the event originated (may be
+	 *                     {@code null} for events outside any ANTLR context)
+	 * @param feature  a short, user-facing feature label (e.g. "async",
+	 *                     "return", "subscript"); used for categorical
+	 *                     filtering
+	 * @param detail   the full human-readable message
+	 */
+	public record DiagnosticEvent(
+			Severity severity,
+			SourceCodeLocation location,
+			String feature,
+			String detail) {
+		public DiagnosticEvent {
+			Objects.requireNonNull(severity, "severity");
+			Objects.requireNonNull(feature, "feature");
+			Objects.requireNonNull(detail, "detail");
+		}
+	}
+
+	/**
+	 * Thrown from {@link #report(Severity, SourceCodeLocation, String, String)}
+	 * when the reporter is in strict mode and an {@link Severity#UNSOUND} event
+	 * is recorded.
+	 */
+	public static final class StrictModeViolation extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		private final DiagnosticEvent event;
+
+		StrictModeViolation(
+				DiagnosticEvent e) {
+			super("[strict] " + e.feature() + " at " + e.location() + ": " + e.detail());
+			this.event = e;
+		}
+
+		public DiagnosticEvent event() {
+			return event;
+		}
+	}
+
+	private final List<DiagnosticEvent> events = new ArrayList<>();
+	private final boolean strict;
+
+	public DiagnosticReporter(
+			boolean strict) {
+		this.strict = strict;
+	}
+
+	/**
+	 * Records a diagnostic event, mirrors it to log4j at the appropriate level,
+	 * and — in strict mode — throws {@link StrictModeViolation} for
+	 * {@link Severity#UNSOUND} events.
+	 *
+	 * @param sev     severity category
+	 * @param at      source location of the construct that triggered the event
+	 *                    (may be {@code null})
+	 * @param feature short feature label for categorical filtering
+	 * @param detail  full human-readable message
+	 *
+	 * @return the recorded event
+	 */
+	public DiagnosticEvent report(
+			Severity sev,
+			SourceCodeLocation at,
+			String feature,
+			String detail) {
+		DiagnosticEvent e = new DiagnosticEvent(sev, at, feature, detail);
+		events.add(e);
+		switch (sev) {
+		case INFO -> LOG.info("[{}] {} at {}: {}", sev, feature, at, detail);
+		case UNSOUND -> LOG.warn("[{}] {} at {}: {}", sev, feature, at, detail);
+		case UNSUPPORTED -> LOG.error("[{}] {} at {}: {}", sev, feature, at, detail);
+		}
+		if (strict && sev == Severity.UNSOUND)
+			throw new StrictModeViolation(e);
+		return e;
+	}
+
+	/**
+	 * Returns an unmodifiable snapshot of all events recorded so far, in the
+	 * order they were reported.
+	 */
+	public List<DiagnosticEvent> events() {
+		return List.copyOf(events);
+	}
+
+	/** Returns the count of events of the given severity. */
+	public long countBy(
+			Severity sev) {
+		return events.stream().filter(e -> e.severity() == sev).count();
+	}
+
+	/** Returns {@code true} iff the reporter is in strict mode. */
+	public boolean strict() {
+		return strict;
+	}
+}

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/ParserContext.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/ParserContext.java
@@ -55,6 +55,7 @@ public final class ParserContext {
 	private String filePath;
 	private boolean currentFileIsPackage;
 	private boolean continueOnUnsupportedStatement;
+	private DiagnosticReporter reporter;
 
 	private Program program;
 	private PythonModuleImportManager importManager;
@@ -99,6 +100,20 @@ public final class ParserContext {
 	public void continueOnUnsupportedStatement(
 			boolean v) {
 		this.continueOnUnsupportedStatement = v;
+	}
+
+	/**
+	 * Returns the structured diagnostic sink used by the frontend. The reporter
+	 * is installed by {@link PyFrontend} during construction and must be
+	 * non-null before any visitor runs.
+	 */
+	public DiagnosticReporter reporter() {
+		return reporter;
+	}
+
+	public void reporter(
+			DiagnosticReporter r) {
+		this.reporter = r;
 	}
 
 	// === parser state fields ===

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/ParserSupport.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/ParserSupport.java
@@ -86,11 +86,17 @@ public final class ParserSupport {
 		return new SourceCodeLocation(source, getLine(pctx), getCol(pctx));
 	}
 
-	// === diagnostics (will move to DiagnosticReporter in Chunk 6) ===
+	// === diagnostics ===
 
 	public <T> T unsupported(
 			ParserRuleContext pctx,
 			String description) {
+		SourceCodeLocation loc = getLocation(pctx);
+		ctx.reporter().report(
+				DiagnosticReporter.Severity.UNSUPPORTED,
+				loc,
+				featureLabel(description, pctx),
+				description);
 		throw new UnsupportedStatementException(
 				description + " at line " + getLine(pctx) + " of " + ctx.filePath());
 	}
@@ -98,8 +104,30 @@ public final class ParserSupport {
 	public void unsound(
 			ParserRuleContext pctx,
 			String description) {
-		LOG.warn(description + " (unsound translation) at line "
-				+ getLine(pctx) + " of " + ctx.filePath());
+		SourceCodeLocation loc = getLocation(pctx);
+		ctx.reporter().report(
+				DiagnosticReporter.Severity.UNSOUND,
+				loc,
+				featureLabel(description, pctx),
+				description + " (unsound translation) at line "
+						+ getLine(pctx) + " of " + ctx.filePath());
+	}
+
+	/**
+	 * Extracts a short, lower-cased feature label from a diagnostic
+	 * description. Used so callers can filter events by category (e.g. "async",
+	 * "return") without coupling to full message wording. Falls back to the
+	 * ANTLR rule-context class name when the description is empty.
+	 */
+	private static String featureLabel(
+			String description,
+			ParserRuleContext pctx) {
+		if (description != null && !description.isBlank()) {
+			String first = description.trim().split("\\s+", 2)[0];
+			if (!first.isEmpty())
+				return first.toLowerCase();
+		}
+		return pctx != null ? pctx.getClass().getSimpleName() : "unknown";
 	}
 
 	// === name resolution ===

--- a/pylisa/src/main/java/it/unive/pylisa/frontend/PyFrontend.java
+++ b/pylisa/src/main/java/it/unive/pylisa/frontend/PyFrontend.java
@@ -75,34 +75,35 @@ public final class PyFrontend {
 	private final String filePath;
 	private final boolean notebook;
 	private final List<Integer> cellOrder;
+	private final boolean strict;
 
 	private CFG init;
 
 	public PyFrontend(
 			String filePath,
 			boolean notebook) {
-		this(filePath, notebook, Collections.emptyList(), null);
+		this(filePath, notebook, Collections.emptyList(), null, false);
 	}
 
 	public PyFrontend(
 			String filePath,
 			boolean notebook,
 			Integer... cellOrder) {
-		this(filePath, notebook, List.of(cellOrder), null);
+		this(filePath, notebook, List.of(cellOrder), null, false);
 	}
 
 	public PyFrontend(
 			String filePath,
 			boolean notebook,
 			List<Integer> cellOrder) {
-		this(filePath, notebook, cellOrder, null);
+		this(filePath, notebook, cellOrder, null, false);
 	}
 
 	public PyFrontend(
 			String filePath,
 			boolean notebook,
 			String sourceRoot) {
-		this(filePath, notebook, Collections.emptyList(), sourceRoot);
+		this(filePath, notebook, Collections.emptyList(), sourceRoot, false);
 	}
 
 	public PyFrontend(
@@ -110,11 +111,33 @@ public final class PyFrontend {
 			boolean notebook,
 			List<Integer> cellOrder,
 			String sourceRoot) {
+		this(filePath, notebook, cellOrder, sourceRoot, false);
+	}
+
+	/**
+	 * Returns a {@link PyFrontend} in strict mode: any {@code UNSOUND}
+	 * diagnostic emitted during parsing is promoted to a
+	 * {@link DiagnosticReporter.StrictModeViolation}. Useful for regression
+	 * tests that want to guarantee no silent approximations occur.
+	 */
+	public static PyFrontend strict(
+			String filePath) {
+		return new PyFrontend(filePath, false, Collections.emptyList(), null, true);
+	}
+
+	public PyFrontend(
+			String filePath,
+			boolean notebook,
+			List<Integer> cellOrder,
+			String sourceRoot,
+			boolean strict) {
 		this.filePath = filePath;
 		this.notebook = notebook;
 		this.cellOrder = cellOrder;
+		this.strict = strict;
 
 		this.ctx = new ParserContext();
+		this.ctx.reporter(new DiagnosticReporter(strict));
 		this.ctx.filePath(filePath);
 		this.ctx.currentFileIsPackage(filePath != null && filePath.endsWith("__init__.py"));
 
@@ -148,6 +171,22 @@ public final class PyFrontend {
 
 	public String getFilePath() {
 		return filePath;
+	}
+
+	/**
+	 * Returns the diagnostic reporter associated with this frontend instance.
+	 * Tests and tooling can inspect {@link DiagnosticReporter#events()} after
+	 * {@link #toLiSAProgram(boolean)} completes to see what the parse produced.
+	 */
+	public DiagnosticReporter reporter() {
+		return ctx.reporter();
+	}
+
+	/**
+	 * Returns {@code true} iff this frontend was constructed in strict mode.
+	 */
+	public boolean strict() {
+		return strict;
 	}
 
 	public Program toLiSAProgram() throws IOException, AnalysisSetupException {

--- a/pylisa/src/test/java/it/unive/pylisa/frontend/FrontendTestSupport.java
+++ b/pylisa/src/test/java/it/unive/pylisa/frontend/FrontendTestSupport.java
@@ -55,13 +55,48 @@ public final class FrontendTestSupport {
 	public static ParseResult parseSnippet(
 			String snippet)
 			throws Exception {
+		return parseSnippetWithFrontend(snippet).result();
+	}
+
+	/**
+	 * Like {@link #parseSnippet(String)} but also exposes the
+	 * {@link PyFrontend} instance so callers can inspect its
+	 * {@link DiagnosticReporter} after the parse completes. Introduced in Chunk
+	 * 6 so {@code UnsoundnessCatalogTest} can verify diagnostic events
+	 * structurally in addition to scraping logs.
+	 */
+	public static ParseWithFrontend parseSnippetWithFrontend(
+			String snippet)
+			throws Exception {
 		Objects.requireNonNull(snippet, "snippet");
 		Path tmp = Files.createTempFile("pylisa-test-", ".py");
 		tmp.toFile().deleteOnExit();
 		Files.writeString(tmp, snippet, StandardOpenOption.TRUNCATE_EXISTING);
 		LOG.debug("parsing snippet at {} ({} chars)", tmp, snippet.length());
 		PyFrontend fe = new PyFrontend(tmp.toString(), false);
-		return new ParseResult(fe.toLiSAProgram(false), tmp);
+		Program program = fe.toLiSAProgram(false);
+		return new ParseWithFrontend(new ParseResult(program, tmp), fe);
+	}
+
+	/**
+	 * Materialises a snippet to a temp file and returns the path without
+	 * parsing it. Used by tests that drive {@link PyFrontend} themselves — e.g.
+	 * strict-mode tests that expect the parse to throw.
+	 */
+	public static Path writeTempSnippet(
+			String snippet)
+			throws IOException {
+		Objects.requireNonNull(snippet, "snippet");
+		Path tmp = Files.createTempFile("pylisa-test-", ".py");
+		tmp.toFile().deleteOnExit();
+		Files.writeString(tmp, snippet, StandardOpenOption.TRUNCATE_EXISTING);
+		return tmp;
+	}
+
+	/** Result of {@link #parseSnippetWithFrontend(String)}. */
+	public record ParseWithFrontend(
+			ParseResult result,
+			PyFrontend frontend) {
 	}
 
 	/**

--- a/pylisa/src/test/java/it/unive/pylisa/frontend/UnsoundnessCatalogTest.java
+++ b/pylisa/src/test/java/it/unive/pylisa/frontend/UnsoundnessCatalogTest.java
@@ -1,7 +1,12 @@
 package it.unive.pylisa.frontend;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import it.unive.pylisa.frontend.DiagnosticReporter.DiagnosticEvent;
+import it.unive.pylisa.frontend.DiagnosticReporter.Severity;
+import java.nio.file.Path;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -9,10 +14,14 @@ import org.junit.jupiter.api.Test;
 /**
  * Layer C: regression-guards for every currently-emitted unsoundness category.
  * <p>
- * Assertions are <strong>keyword-based</strong> rather than exact-text matches
- * because Chunk 6 rewrites the diagnostic emission path. Each test pins the
- * <em>category</em> of warning, not its wording.
- * <p>
+ * Each test pins a category in two ways:
+ * <ol>
+ * <li>Log-based: via {@link LoggerCaptor}, confirms the diagnostic still
+ * surfaces through log4j so users / existing tooling keep seeing it.</li>
+ * <li>Reporter-based: via {@link DiagnosticReporter#events()}, confirms the
+ * structured event is recorded with {@code Severity.UNSOUND} and the expected
+ * feature label.</li>
+ * </ol>
  * If a new unsoundness site is introduced in the frontend, add a case here so
  * the safety net stays exhaustive.
  */
@@ -25,52 +34,94 @@ final class UnsoundnessCatalogTest {
 	@Test
 	void async_def_is_treated_as_def_with_warning() throws Exception {
 		try (LoggerCaptor cap = LoggerCaptor.forPackage(FRONTEND_LOGGER)) {
-			FrontendTestSupport.parseSnippet("async def f():\n    pass\n");
+			var pf = FrontendTestSupport.parseSnippetWithFrontend("async def f():\n    pass\n");
 			LOG.debug("warnings: {}", cap.warnings());
 			assertThat(cap.warnings()).anyMatch(s -> s.toLowerCase().contains("async"));
+			assertUnsoundFeaturesContain(pf.frontend().reporter().events(), "async");
 		}
 	}
 
 	@Test
 	void async_statement_is_treated_as_sync_with_warning() throws Exception {
 		try (LoggerCaptor cap = LoggerCaptor.forPackage(FRONTEND_LOGGER)) {
-			FrontendTestSupport.parseSnippet(
+			var pf = FrontendTestSupport.parseSnippetWithFrontend(
 					"async def f():\n    async for x in agen():\n        y = x\n");
 			assertThat(cap.warnings()).anyMatch(s -> s.toLowerCase().contains("async"));
+			assertUnsoundFeaturesContain(pf.frontend().reporter().events(), "async");
 		}
 	}
 
 	@Test
 	void await_expression_is_stripped_with_warning() throws Exception {
 		try (LoggerCaptor cap = LoggerCaptor.forPackage(FRONTEND_LOGGER)) {
-			FrontendTestSupport.parseSnippet("async def f():\n    x = await other()\n");
+			var pf = FrontendTestSupport.parseSnippetWithFrontend(
+					"async def f():\n    x = await other()\n");
 			assertThat(cap.warnings()).anyMatch(s -> s.toLowerCase().contains("await"));
+			assertUnsoundFeaturesContain(pf.frontend().reporter().events(), "await");
 		}
 	}
 
 	@Test
 	void multiple_return_values_emit_warning() throws Exception {
 		try (LoggerCaptor cap = LoggerCaptor.forPackage(FRONTEND_LOGGER)) {
-			FrontendTestSupport.parseSnippet("def f():\n    return 1, 2\n");
+			var pf = FrontendTestSupport.parseSnippetWithFrontend("def f():\n    return 1, 2\n");
 			assertThat(cap.warnings()).anyMatch(s -> s.toLowerCase().contains("return"));
+			List<DiagnosticEvent> unsound = pf.frontend().reporter().events().stream()
+					.filter(e -> e.severity() == Severity.UNSOUND)
+					.toList();
+			assertThat(unsound).isNotEmpty();
 		}
 	}
 
 	@Test
 	void try_except_is_modeled_as_bypass_with_warning() throws Exception {
 		try (LoggerCaptor cap = LoggerCaptor.forPackage(FRONTEND_LOGGER)) {
-			FrontendTestSupport.parseSnippet(
+			var pf = FrontendTestSupport.parseSnippetWithFrontend(
 					"def f():\n    try:\n        x = 1\n    except Exception:\n        x = 0\n");
 			assertThat(cap.warnings()).anyMatch(s -> s.toLowerCase().contains("except")
 					|| s.toLowerCase().contains("try"));
+			List<DiagnosticEvent> unsound = pf.frontend().reporter().events().stream()
+					.filter(e -> e.severity() == Severity.UNSOUND)
+					.toList();
+			assertThat(unsound).isNotEmpty();
 		}
 	}
 
 	@Test
 	void multiple_subscripts_emit_warning() throws Exception {
 		try (LoggerCaptor cap = LoggerCaptor.forPackage(FRONTEND_LOGGER)) {
-			FrontendTestSupport.parseSnippet("def f(m):\n    x = m[1, 2]\n");
+			var pf = FrontendTestSupport.parseSnippetWithFrontend("def f(m):\n    x = m[1, 2]\n");
 			assertThat(cap.warnings()).anyMatch(s -> s.toLowerCase().contains("subscript"));
+			assertUnsoundFeaturesContain(pf.frontend().reporter().events(), "multiple");
 		}
+	}
+
+	@Test
+	void strict_mode_promotes_async_unsoundness_to_failure() throws Exception {
+		Path tmp = FrontendTestSupport.writeTempSnippet("async def f():\n    pass\n");
+		assertThatThrownBy(() -> PyFrontend.strict(tmp.toString()).toLiSAProgram(false))
+				.isInstanceOf(DiagnosticReporter.StrictModeViolation.class)
+				.hasMessageContaining("async");
+	}
+
+	@Test
+	void non_strict_mode_records_events_without_throwing() throws Exception {
+		var pf = FrontendTestSupport.parseSnippetWithFrontend("async def f():\n    pass\n");
+		assertThat(pf.frontend().strict()).isFalse();
+		assertThat(pf.frontend().reporter().countBy(Severity.UNSOUND)).isGreaterThan(0);
+	}
+
+	/**
+	 * Asserts the reporter recorded at least one {@code UNSOUND} event whose
+	 * feature label matches the expected category (substring match, so tests
+	 * survive minor label tweaks).
+	 */
+	private static void assertUnsoundFeaturesContain(
+			List<DiagnosticEvent> events,
+			String expectedFeature) {
+		assertThat(events)
+				.filteredOn(e -> e.severity() == Severity.UNSOUND)
+				.extracting(DiagnosticEvent::feature)
+				.anyMatch(f -> f.toLowerCase().contains(expectedFeature.toLowerCase()));
 	}
 }


### PR DESCRIPTION
Introduce a structured DiagnosticReporter that replaces the scattered unsound/unsupported helpers with typed events. Every event is recorded in-memory (queryable via reporter.events()) AND mirrored to log4j so existing LoggerCaptor-based tests keep working without changes.

Additions
- DiagnosticReporter with Severity enum (INFO/UNSOUND/UNSUPPORTED), DiagnosticEvent record, StrictModeViolation exception.
- ParserContext.reporter() accessor, wired in PyFrontend's constructor.
- PyFrontend.strict(path) static factory + new 5-arg constructor with a `strict` flag (default false across all existing overloads).
- PyFrontend.reporter() accessor for tests/tooling.
- FrontendTestSupport.parseSnippetWithFrontend() and writeTempSnippet().

Migrations
- ParserSupport.unsound/unsupported now funnel through ctx.reporter().report(...); featureLabel() picks a short category from the first word of the description. Zero call-site changes: the 9 unsound() and 8 unsupported() callers stay identical.

Tests
- UnsoundnessCatalogTest: each of the 6 existing tests now asserts both the log stream (unchanged) AND reporter.events() structurally.
- New: strict_mode_promotes_async_unsoundness_to_failure.
- New: non_strict_mode_records_events_without_throwing.

Out of scope (per plan)
- The ~40 direct `throw new UnsupportedStatementException` stubs — consolidated in Chunk 8.
- continueOnUnsupportedStatement semantics — untouched (orthogonal).
- log4j2.xml — no change needed, root DEBUG already covers the class.

./gradlew test: same pass/fail set as the chunk-5 baseline (235 tests total, 5 pre-existing failures in Classes.* and Evaluation.functions_redecl — all unchanged).